### PR TITLE
Remove att from generate_function_decompme

### DIFF
--- a/scripts/generate_function_decompme
+++ b/scripts/generate_function_decompme
@@ -8,4 +8,4 @@ RESOURCES_DIR=$BASE_DIR/resources
 CONFIG_DIR=$BASE_DIR/config
 
 FUNCTION_NAME=$1
-satsuki --mapping-file $CONFIG_DIR/mapping.toml disassemble --att --force-address-zero $RESOURCES_DIR/game.exe $FUNCTION_NAME
+satsuki --mapping-file $CONFIG_DIR/mapping.toml disassemble --force-address-zero $RESOURCES_DIR/game.exe $FUNCTION_NAME


### PR DESCRIPTION
decompme now uses intel syntax for target assembly input.