### PR TITLE
Couple misc fixes

### DIFF
--- a/src/GameErrorContext.cpp
+++ b/src/GameErrorContext.cpp
@@ -21,7 +21,7 @@ const char *GameErrorContextFatal(GameErrorContext *ctx, const char *fmt, ...)
         strcpy(ctx->m_BufferEnd, tmpBuffer);
 
         ctx->m_BufferEnd += tmpBufferSize;
-        *ctx->m_BufferEnd = '¥0';
+        *ctx->m_BufferEnd = '\0';
     }
 
     va_end(args);
@@ -47,7 +47,7 @@ const char *GameErrorContextLog(GameErrorContext *ctx, const char *fmt, ...)
         strcpy(ctx->m_BufferEnd, tmpBuffer);
 
         ctx->m_BufferEnd += tmpBufferSize;
-        *ctx->m_BufferEnd = '¥0';
+        *ctx->m_BufferEnd = '\0';
     }
 
     va_end(args);

--- a/src/GameWindow.hpp
+++ b/src/GameWindow.hpp
@@ -12,6 +12,9 @@ struct GameWindow
     i32 lastActiveAppValue;
     i32 isAppActive;
     u8 curFrame;
+    i32 screenSaveActive;
+    i32 lowPowerActive;
+    i32 powerOffActive;
 };
 
 extern GameWindow g_GameWindow;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -490,10 +490,6 @@ void CreateGameWindow(HINSTANCE hInstance)
     g_GameContext.hwndGameWindow = g_GameWindow.window;
 }
 
-static i32 g_ScreenSaveActive;
-static i32 g_LowPowerActive;
-static i32 g_PowerOffActive;
-
 int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
     i32 renderResult = 0;
@@ -523,9 +519,9 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
         return 1;
     }
 
-    SystemParametersInfo(SPI_GETSCREENSAVEACTIVE, 0, &g_ScreenSaveActive, 0);
-    SystemParametersInfo(SPI_GETLOWPOWERACTIVE, 0, &g_LowPowerActive, 0);
-    SystemParametersInfo(SPI_GETPOWEROFFACTIVE, 0, &g_PowerOffActive, 0);
+    SystemParametersInfo(SPI_GETSCREENSAVEACTIVE, 0, &g_GameWindow.screenSaveActive, 0);
+    SystemParametersInfo(SPI_GETLOWPOWERACTIVE, 0, &g_GameWindow.lowPowerActive, 0);
+    SystemParametersInfo(SPI_GETPOWEROFFACTIVE, 0, &g_GameWindow.powerOffActive, 0);
     SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, 0, NULL, SPIF_SENDCHANGE);
     SystemParametersInfo(SPI_SETLOWPOWERACTIVE, 0, NULL, SPIF_SENDCHANGE);
     SystemParametersInfo(SPI_SETPOWEROFFACTIVE, 0, NULL, SPIF_SENDCHANGE);
@@ -620,9 +616,9 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
     else
     {
         FileSystem::WriteDataToFile(TH_CONFIG_FILE, &g_GameContext.cfg, sizeof(g_GameContext.cfg));
-        SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, g_ScreenSaveActive, NULL, SPIF_SENDCHANGE);
-        SystemParametersInfo(SPI_SETLOWPOWERACTIVE, g_LowPowerActive, NULL, SPIF_SENDCHANGE);
-        SystemParametersInfo(SPI_SETPOWEROFFACTIVE, g_PowerOffActive, NULL, SPIF_SENDCHANGE);
+        SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, g_GameWindow.screenSaveActive, NULL, SPIF_SENDCHANGE);
+        SystemParametersInfo(SPI_SETLOWPOWERACTIVE, g_GameWindow.lowPowerActive, NULL, SPIF_SENDCHANGE);
+        SystemParametersInfo(SPI_SETPOWEROFFACTIVE, g_GameWindow.powerOffActive, NULL, SPIF_SENDCHANGE);
 
         if (g_GameContext.d3dIface != NULL)
         {


### PR DESCRIPTION
This fixes a couple mistakes:

- A handful of yens still remained from the shift-jis->utf8 transition. This moves them over.
- It moves a couple of globals related to the screen state to g_GameWindow, where they belong.