### PR TITLE
Correctly name PDB file

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -43,7 +43,7 @@ FileSystem::WriteDataToFile
 Supervisor::AddedCallback
 Supervisor::LoadPbg3
 Supervisor::RegisterChain
-Supervisor::Parse
+Supervisor::LoadConfig
 InitD3dDevice
 InitD3dRendering
 Clear

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -52,7 +52,8 @@ def configure(build_type):
         writer.rule("as", "$gas -o $out $in")
         writer.rule("rc", "$rc /fo $out $in")
         writer.rule(
-            "link", "$link /out:$out $link_flags /debug /pdb:$out.pdb $link_libs $in"
+            "link",
+            """cmd /c "for %F in ("$out") do $link /out:%F $link_flags /debug /pdb:%~pdnF.pdb $link_libs $in" """,
         )
         writer.rule(
             "copyicon",

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -31,7 +31,7 @@ i32 InitD3dInterface(void)
 }
 
 // TODO: Not a perfect match.
-ZunResult Supervisor::Parse(char *path)
+ZunResult Supervisor::LoadConfig(char *path)
 {
     u8 *data;
     FILE *wavFile;

--- a/src/Supervisor.hpp
+++ b/src/Supervisor.hpp
@@ -86,7 +86,7 @@ struct Supervisor
     i32 LoadPbg3(i32 pbg3FileIdx, char *filename);
     void ReleasePbg3(i32 pbg3FileIdx);
 
-    ZunResult Parse(char *path);
+    ZunResult LoadConfig(char *path);
 
     void TickTimer(i32 *frames, f32 *subframes);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -504,7 +504,7 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
 
     g_Supervisor.hInstance = hInstance;
 
-    if (g_Supervisor.Parse(TH_CONFIG_FILE) != ZUN_SUCCESS)
+    if (g_Supervisor.LoadConfig(TH_CONFIG_FILE) != ZUN_SUCCESS)
     {
         g_GameErrorContext.Flush();
         return -1;


### PR DESCRIPTION
After the switch to ninja, the PDB file was named th06e.exe.pdb, which broke a lot of tools that assume the debug file is in th06e.pdb. This commit fixes it by passing the correct name to link.exe.