### PR TITLE
Allow torrent downloading of MSVC 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ log.txt
 scripts/dls
 scripts/prefix
 build.ninja
+__pycache__

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The build system has the following package requirements:
 - `python3` >= 3.4
 - `msiextract` (On linux/macos only)
 - `wine` (on linux/macos only, prefer CrossOver on macOS to avoid possible CL.EXE heap issues)
+- `aria2c` (optional, allows for torrent downloads, will automatically install on Windows if selected.)
 
 The rest of the build system is constructed out of Visual Studio 2002 and DirectX 8.0 from the Web Archive.
 

--- a/scripts/create_th06_prefix
+++ b/scripts/create_th06_prefix
@@ -22,6 +22,7 @@ $WINE wineboot --init
 mkdir -p $MAIN_DRIVE_PATH
 
 echo "Creating devenv in $MAIN_DRIVE_PATH"
-python3 $SCRIPT_DIR/create_devenv.py $SCRIPT_DIR/dls $MAIN_DRIVE_PATH
+# #@ is used to pass all arguments to the python script
+python3 $SCRIPT_DIR/create_devenv.py $SCRIPT_DIR/dls $MAIN_DRIVE_PATH $@
 
 echo "DONE"


### PR DESCRIPTION
This PR adds the ability for torrents to be downloaded (from archive.org), using aria2c, it will be automatically downloaded and put into the dl_cache folder on Windows, and on Linux it needs to be in your PATH (install it with your package manager of choice). This offers ~3-10x improvement on download times (30+ minutes to 3-10 minutes!!), and will only get better if people decide to seed it.