### PR TITLE
Default builds to single-job builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       id: install_prefix
       run: python scripts/create_devenv.py scripts/dls scripts/prefix
     - name: Build binary
-      run: python scripts/build.py
+      run: python scripts/build.py -j0
     - uses: actions/upload-artifact@v3
       with:
         name: th06e
@@ -57,7 +57,7 @@ jobs:
       id: install_prefix
       run: python scripts/create_devenv.py scripts/dls scripts/prefix
     - name: Build binary
-      run: python scripts/build.py --build-type diffbuild
+      run: python scripts/build.py -j0 --build-type diffbuild
     - uses: actions/upload-artifact@v3
       with:
         name: th06e-diff
@@ -92,7 +92,7 @@ jobs:
       id: install_prefix
       run: python scripts/create_devenv.py scripts/dls scripts/prefix
     - name: Build binary
-      run: python scripts/build.py --build-type dllbuild
+      run: python scripts/build.py -j0 --build-type dllbuild
     - uses: actions/upload-artifact@v3
       with:
         name: th06e-dll

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -7,12 +7,15 @@ from winhelpers import run_windows_program
 SCRIPTS_DIR = Path(__file__).parent
 
 
-def build(build_type, verbose=False):
+def build(build_type, verbose=False, jobs=1):
     configure(build_type)
 
     ninja_args = []
     if verbose:
         ninja_args += ["-v"]
+
+    if jobs != 0:
+        ninja_args += ["-j" + str(jobs)]
 
     if build_type == BuildType.TESTS:
         ninja_args += ["build/th06e-tests.exe"]
@@ -37,6 +40,14 @@ def main():
         choices=["normal", "diffbuild", "tests", "dllbuild"],
         default="normal",
     )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        help="""Number of jobs to run in parallel. Set to 0 to run one job per CPU core. Defaults to 1.
+        Note that parallel builds may not work when running through wine. See https://github.com/happyhavoc/th06/issues/79 for more information.""",
+    )
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
@@ -50,7 +61,7 @@ def main():
     elif args.build_type == "dllbuild":
         build_type = BuildType.DLLBUILD
 
-    build(build_type, args.verbose)
+    build(build_type, args.verbose, args.jobs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #79 

It looks like there's a wine bug that causes parallel builds to fail.

To fix this, default to single-threaded builds, and add a new flag `-j0` to re-enable parallel builds.