### PR TITLE
Stub Pbg3Archive ctor/dtor to fix dllbuild crashes

### DIFF
--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -40,3 +40,5 @@ MainMenu::MoveCursor
 MainMenu::RegisterChain
 MainMenu::DrawMenuItem
 ReplayDoStuff
+Pbg3Archive::Pbg3Archive
+Pbg3Archive::~Pbg3Archive


### PR DESCRIPTION
TH06 has a weird double free issue in Pbg3Archive, which is benign in the official implementation, but causes our reimplementation to crash for whatever reason. Let's just use the official impl until we have a clearer idea of what's going on.