### PR TITLE
fix silly bug in MainMenu.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ scripts/dls
 scripts/prefix
 build.ninja
 __pycache__
+scripts/msvc70/
+.vscode/

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -161,7 +161,7 @@ ZunResult MainMenu::DrawStartMenu(void)
     }
     if (this->stateTimer >= 0x14)
     {
-        if (WAS_PRESSED(KEY_ENTER | KEY_SHOOT))
+        if (WAS_PRESSED(KEY_SHOOT) || WAS_PRESSED(KEY_ENTER))
         {
             switch (this->cursor)
             {


### PR DESCRIPTION
This allows both the enter key and the shoot button to be used to enter submenus instead of just the enter key :)