### PR TITLE
Improve accuracy of AsciiManager::OnUpdate

### DIFF
--- a/src/AsciiManager.cpp
+++ b/src/AsciiManager.cpp
@@ -37,10 +37,13 @@ ChainCallbackResult AsciiManager::OnUpdate(AsciiManager *mgr)
             ZunTimer *timer = &curPopup->timer;
             timer->previous = timer->current;
             g_Supervisor.TickTimer(&timer->current, &timer->subFrame);
-            curPopup->inUse = curPopup->timer.current > 60;
+            if ((bool)((curPopup->timer).current > 60))
+            {
+                curPopup->inUse = false;
+            }
         }
     }
-    if (g_GameManager.isInGameMenu)
+    else if (g_GameManager.isInGameMenu)
     {
         mgr->gameMenu.OnUpdateGameMenu();
     }

--- a/src/AsciiManager.cpp
+++ b/src/AsciiManager.cpp
@@ -37,7 +37,7 @@ ChainCallbackResult AsciiManager::OnUpdate(AsciiManager *mgr)
             ZunTimer *timer = &curPopup->timer;
             timer->previous = timer->current;
             g_Supervisor.TickTimer(&timer->current, &timer->subFrame);
-            if ((bool)((curPopup->timer).current > 60))
+            if ((bool)(curPopup->timer.current > 60))
             {
                 curPopup->inUse = false;
             }


### PR DESCRIPTION
`curPopup->inUse` condition was backwards, making the pickup text appear for 1 frame and then disappear, plus, doing it this way, _somehow_, improves the accuracy almost matching the original