### PR TITLE
Cache game binary

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -43,7 +43,14 @@ jobs:
         fileName: x86_64-windows-satsuki.exe
     - name: Add satsuki to prefix
       run: python scripts/create_devenv.py --only satsuki scripts/dls scripts/prefix
+    - name: Fetch game binary from cache.
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: resources/game.exe
+        key: 9f76483c46256804792399296619c1274363c31cd8f1775fafb55106fb852245
     - name: Download original game binary for comparison
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         curl -L $env:ORIGINAL_URL -o resources/game.exe
         $hash = (Get-FileHash resources/game.exe).Hash


### PR DESCRIPTION
Currently, we'll keep hitting archive.org with requests to download the th06 game binary in CI. This is not ideal, as archive.org is not very reliable, and we don't really want to hit them with more request than we really need, out of courtesy.

So we setup a cache to keep a copy of the binary in a github cache.