### PR TITLE
Ghidra devenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.4'
     - name: Get toolchain from cache
       id: cache-toolchain
       uses: actions/cache/restore@v3
@@ -44,6 +47,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.4'
     - name: Get toolchain from cache
       id: cache-toolchain
       uses: actions/cache/restore@v3
@@ -79,6 +85,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.4'
     - name: Get toolchain from cache
       id: cache-toolchain
       uses: actions/cache/restore@v3

--- a/README.md
+++ b/README.md
@@ -54,14 +54,41 @@ python3 ./scripts/build.py
 This will automatically generate a ninja build script `build.ninja`, and run
 ninja on it.
 
-## Reverse Engineering
+## Contributing
+
+### Reverse Engineering
 
 You can find an XML export of our Ghidra RE in the companion repository
-[th06-re]. This repo is updated nightly through [`scripts/export_ghidra_database.py`],
-and its history matches the checkin history from our team's Ghidra Server.
+[th06-re], in the `xml` branch. This repo is updated nightly through
+[`scripts/export_ghidra_database.py`], and its history matches the checkin
+history from our team's Ghidra Server.
 
 If you wish to help us in our Reverse Engineering effort, please contact
 @roblabla on discord so we can give you an account on the Ghidra Server.
+
+### Reimplementation
+
+The easiest way to work on the reimplementation is through the use of
+[`objdiff`](https://github.com/encounter/objdiff). Here's how to get started:
+
+1. First, follow the instruction above to get a devenv setup.
+1. Copy the original `東方紅魔郷.exe` file (version 1.02h) to the
+   `resources/game.exe` folder. This will be used as the source to compare the
+   reimplementations against.
+1. Download the latest version of objdiff.
+1. Run `python3 scripts/export_ghidra_objs.py --import-xml`. This will extract
+   from `resources/game.exe` the object files that objdiff can compare against.
+1. Finally, run objdiff and open the th06 project.
+
+#### Choosing a function to decompile
+
+The easiest is to look at the `config/stubbed.csv` files. Those are all
+functions that are automatically stubbed out. You should pick one of them, open
+the associated object file in objdiff, and click on the function of interest.
+
+Then, open the correct `cpp` file, copy/paste the declaration, and start
+hacking! It may be useful to take the ghidra decompiler output as a base. You
+can find this output in the [th06-re] repository.
 
 # Credits
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -87,7 +87,7 @@ def main():
 
     if args.object_name is not None:
         object_name = Path(args.object_name).name
-        target = f"build/objdiff/reimpl/{object_name}"
+        target = "build/objdiff/reimpl/" + object_name
     elif args.target is not None:
         target = args.target
 

--- a/scripts/export_ghidra_database.py
+++ b/scripts/export_ghidra_database.py
@@ -25,7 +25,7 @@ def fetchVersions(args):
     with tempfile.NamedTemporaryFile(prefix="versions") as f:
         ghidra_helpers.runAnalyze(
             args.GHIDRA_REPO_NAME,
-            program=args.program,
+            process=args.program,
             username=args.username,
             ssh_key=args.ssh_key,
             extraArgs=["-preScript", "ExportFileVersions.java", f.name],

--- a/scripts/export_ghidra_database.py
+++ b/scripts/export_ghidra_database.py
@@ -28,7 +28,7 @@ def fetchVersions(args):
             process=args.program,
             username=args.username,
             ssh_key=args.ssh_key,
-            extraArgs=["-preScript", "ExportFileVersions.java", f.name],
+            pre_scripts=[["ExportFileVersions.java", f.name]],
         )
         versions = json.loads(f.read())
     versions.sort(key=lambda x: x["version"])
@@ -62,7 +62,7 @@ def export(args, version: dict):
         program=args.program,
         username=args.username,
         ssh_key=args.ssh_key,
-        extraArgs=["-preScript", script, str(out), str(version["version"])],
+        pre_scripts=[[script, str(out), str(version["version"])]],
     )
 
     if args.EXPORT_TYPE == XML:

--- a/scripts/export_ghidra_objs.py
+++ b/scripts/export_ghidra_objs.py
@@ -22,7 +22,7 @@ def main():
     parser.add_argument("--program", help="Program to export", default="th06_102h.exe")
     args = parser.parse_args()
 
-    os.makedirs(str(SCRIPT_PATH.parent / "build" / "objdiff" / "reimpl"), exist_ok=True)
+    os.makedirs(str(SCRIPT_PATH.parent / "build" / "objdiff" / "orig"), exist_ok=True)
 
     if args.import_xml:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/scripts/export_ghidra_objs.py
+++ b/scripts/export_ghidra_objs.py
@@ -32,10 +32,9 @@ def main():
             ghidra_helpers.runAnalyze(
                 str(tempdir),
                 "Touhou 06",
+                import_file=str(SCRIPT_PATH.parent / "resources" / "game.exe"),
                 analysis=True,
                 extraArgs=[
-                    "-import",
-                    SCRIPT_PATH.parent / "resources" / "game.exe",
                     "-postScript",
                     SCRIPT_PATH / "ghidra" / "ImportFromXml.java",
                     filename,
@@ -52,7 +51,7 @@ def main():
         ghidra_helpers.runAnalyze(
             repo,
             project_name,
-            program,
+            process=program,
             extraArgs=[
                 "-preScript",
                 SCRIPT_PATH / "ghidra" / "ExportDelinker.java",

--- a/scripts/export_ghidra_objs.py
+++ b/scripts/export_ghidra_objs.py
@@ -34,13 +34,12 @@ def main():
                 "Touhou 06",
                 import_file=str(SCRIPT_PATH.parent / "resources" / "game.exe"),
                 analysis=True,
-                extraArgs=[
-                    "-postScript",
-                    SCRIPT_PATH / "ghidra" / "ImportFromXml.java",
-                    filename,
-                    "-postScript",
-                    SCRIPT_PATH / "ghidra" / "ExportDelinker.java",
-                    str(SCRIPT_PATH.parent / "build" / "objdiff" / "orig"),
+                post_scripts=[
+                    ["ImportFromXml.java", filename],
+                    [
+                        "ExportDelinker.java",
+                        str(SCRIPT_PATH.parent / "build" / "objdiff" / "orig"),
+                    ],
                 ],
             )
     else:
@@ -52,10 +51,11 @@ def main():
             repo,
             project_name,
             process=program,
-            extraArgs=[
-                "-preScript",
-                SCRIPT_PATH / "ghidra" / "ExportDelinker.java",
-                str(SCRIPT_PATH.parent / "build" / "objdiff" / "orig"),
+            pre_scripts=[
+                [
+                    "ExportDelinker.java",
+                    str(SCRIPT_PATH.parent / "build" / "objdiff" / "orig"),
+                ]
             ],
         )
 

--- a/scripts/generate_objdiff_objs.py
+++ b/scripts/generate_objdiff_objs.py
@@ -35,7 +35,7 @@ def rename_symbols(filename):
             elif namespace != class_name.encode("utf8"):
                 continue
 
-            offset = obj.string_table.append(func_name)
+            offset = obj.string_table.append(namespace + b"::" + func_name)
             sym_obj.name = b"\0\0\0\0" + struct.pack("I", offset)
 
     if not reimpl_folder.exists():

--- a/scripts/ghidra/ImportFromXml.java
+++ b/scripts/ghidra/ImportFromXml.java
@@ -1,0 +1,55 @@
+/*
+ * LICENSE
+ */
+// Description
+//@author roblabla
+//@category exports
+//@keybinding
+//@menupath Skeleton
+//@toolbar Skeleton
+import ghidra.app.script.GhidraScript;
+import ghidra.app.util.Option;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.LoadSpec;
+import ghidra.app.util.opinion.XmlLoader;
+import ghidra.formats.gfilesystem.FSRL;
+import ghidra.formats.gfilesystem.FileSystemService;
+import ghidra.framework.model.DomainFile;
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.mem.Memory;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ImportFromXml extends GhidraScript
+{
+    @Override protected void run() throws Exception
+    {
+        File inFile = askFile("Input XML", "");
+
+        XmlLoader loader = new XmlLoader();
+
+        FSRL fsrl = FileSystemService.getInstance().getLocalFSRL(inFile);
+        ByteProvider bp = FileSystemService.getInstance().getByteProvider(fsrl, false, monitor);
+
+        Collection<LoadSpec> specs = loader.findSupportedLoadSpecs(bp);
+        if (specs.isEmpty())
+        {
+            throw new Exception("No specs found");
+        }
+        if (specs.size() > 1)
+        {
+            throw new Exception("More than 1 spec found");
+        }
+
+        LoadSpec loadSpec = specs.iterator().next();
+        MessageLog messageLog = new MessageLog();
+
+        ArrayList<Option> opts = new ArrayList();
+        opts.add(new Option("Memory Blocks", false));
+        loader.loadInto(bp, loadSpec, opts, messageLog, currentProgram, monitor);
+
+        this.println(messageLog.toString());
+    }
+}

--- a/scripts/ghidra_helpers.py
+++ b/scripts/ghidra_helpers.py
@@ -9,16 +9,22 @@ SCRIPT_PATH = Path(os.path.realpath(__file__)).parent
 
 
 def findAnalyzeHeadless():
+    ghidra_home = None
+    if (SCRIPT_PATH / "prefix" / "ghidra").exists():
+        ghidra_home = SCRIPT_PATH / "prefix" / "ghidra"
+
     # The standard way to locate ghidra is to look at the GHIDRA_HOME
     # environment variable, which points to the ghidra installation folder.
-    if os.getenv("GHIDRA_HOME") is not None:
+    elif os.getenv("GHIDRA_HOME") is not None:
         ghidra_home = Path(os.getenv("GHIDRA_HOME"))
+
+    if ghidra_home is not None:
         if os.name == "nt":
             analyze_headless = ghidra_home / "support" / "analyzeHeadless.bat"
         else:
             analyze_headless = ghidra_home / "support" / "analyzeHeadless"
         if analyze_headless.exists():
-            return analyze_headless
+            return str(analyze_headless)
 
     # ArchLinux and Nix add a ghidra-analyzeHeadless symlink that points to the
     # analyzeHeadless script of the ghidra installation.

--- a/scripts/ghidra_helpers.py
+++ b/scripts/ghidra_helpers.py
@@ -38,7 +38,8 @@ def findAnalyzeHeadless():
 def runAnalyze(
     ghidra_repo_name,
     project_name="Touhou 06",
-    program=None,
+    process=None,
+    import_file=None,
     analysis=False,
     username=None,
     ssh_key=None,
@@ -49,6 +50,13 @@ def runAnalyze(
     if not re.match("^ghidra://", ghidra_repo_name):
         # Set a project name
         commonAnalyzeHeadlessArgs += [project_name]
+
+    if process and import_file:
+        raise Exception("Cannot provide both import and process")
+    elif process:
+        commonAnalyzeHeadlessArgs += ["-process", process]
+    elif import_file:
+        commonAnalyzeHeadlessArgs += ["-import", import_file]
 
     commonAnalyzeHeadlessArgs += [
         "-readOnly",
@@ -61,10 +69,6 @@ def runAnalyze(
 
     if ssh_key:
         commonAnalyzeHeadlessArgs += ["-keystore", ssh_key]
-
-    # TODO: If program is not provided, export all files from server.
-    if program:
-        commonAnalyzeHeadlessArgs += ["-process", program]
 
     commonAnalyzeHeadlessEnv = os.environ.copy()
     if username is not None:

--- a/scripts/ghidra_helpers.py
+++ b/scripts/ghidra_helpers.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import re
+import shlex
 import shutil
 import subprocess
 
@@ -95,7 +96,7 @@ def runAnalyze(
             f"-Duser.name={username} " + os.environ.get("_JAVA_OPTIONS", "")
         )
 
-    print("Running " + str(commonAnalyzeHeadlessArgs))
+    print("Running " + " ".join(shlex.quote(x) for x in commonAnalyzeHeadlessArgs))
     return subprocess.run(
         commonAnalyzeHeadlessArgs, env=commonAnalyzeHeadlessEnv, check=True
     )

--- a/scripts/ghidra_helpers.py
+++ b/scripts/ghidra_helpers.py
@@ -43,7 +43,8 @@ def runAnalyze(
     analysis=False,
     username=None,
     ssh_key=None,
-    extraArgs=[],
+    pre_scripts=[],
+    post_scripts=[],
 ):
     commonAnalyzeHeadlessArgs = [findAnalyzeHeadless(), ghidra_repo_name]
 
@@ -70,12 +71,25 @@ def runAnalyze(
     if ssh_key:
         commonAnalyzeHeadlessArgs += ["-keystore", ssh_key]
 
+    for pre_script in pre_scripts:
+        if isinstance(pre_script, list):
+            commonAnalyzeHeadlessArgs += ["-prescript"] + pre_script
+        elif isinstance(pre_script, str):
+            commonAnalyzeHeadlessArgs += ["-prescript", pre_script]
+
+    for post_script in post_scripts:
+        if isinstance(post_script, list):
+            commonAnalyzeHeadlessArgs += ["-postscript"] + post_script
+        elif isinstance(post_script, str):
+            commonAnalyzeHeadlessArgs += ["-postscript", post_script]
+
     commonAnalyzeHeadlessEnv = os.environ.copy()
     if username is not None:
         commonAnalyzeHeadlessEnv["_JAVA_OPTIONS"] = (
             f"-Duser.name={username} " + os.environ.get("_JAVA_OPTIONS", "")
         )
 
-    allArgs = commonAnalyzeHeadlessArgs + extraArgs
-    print("Running " + str(allArgs))
-    return subprocess.run(allArgs, env=commonAnalyzeHeadlessEnv, check=True)
+    print("Running " + str(commonAnalyzeHeadlessArgs))
+    return subprocess.run(
+        commonAnalyzeHeadlessArgs, env=commonAnalyzeHeadlessEnv, check=True
+    )

--- a/scripts/update_mapping.py
+++ b/scripts/update_mapping.py
@@ -16,7 +16,7 @@ def updateMapping(args, mapping_path):
         process=args.program,
         username=args.username,
         ssh_key=args.ssh_key,
-        extraArgs=["-preScript", "GenerateMapping.java", mapping_path],
+        pre_scripts=[["GenerateMapping.java", mapping_path]],
     )
 
 

--- a/scripts/update_mapping.py
+++ b/scripts/update_mapping.py
@@ -13,7 +13,7 @@ SCRIPT_PATH = Path(os.path.realpath(__file__)).parent
 def updateMapping(args, mapping_path):
     ghidra_helpers.runAnalyze(
         args.GHIDRA_REPO_NAME,
-        program=args.program,
+        process=args.program,
         username=args.username,
         ssh_key=args.ssh_key,
         extraArgs=["-preScript", "GenerateMapping.java", mapping_path],


### PR DESCRIPTION
Adds (a custom) ghidra and ghidra-delinker-extension to the devenv, to simplify the objdiff workflow.

With this done, getting started with objdiff should be as simple as:

1. Adding the original th06 executable in resources/game.exe
1. Running `python3 scripts/export_ghidra_objs.py --import-xml`
1. Starting objdiff