### PR TITLE
Export bool as-is in ghidra

### DIFF
--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -40,6 +40,7 @@ if args.output:
 
 ret_vals = {
     "void": "",
+    "bool": "false",
     "u8": "0",
     "i8": "0",
     "u16": "0",

--- a/scripts/ghidra/GenerateMapping.java
+++ b/scripts/ghidra/GenerateMapping.java
@@ -18,6 +18,7 @@ public class GenerateMapping extends GhidraScript
     {
         switch (ty.toString())
         {
+        case "bool":
         case "u8":
         case "i8":
         case "u16":
@@ -31,7 +32,6 @@ public class GenerateMapping extends GhidraScript
         case "undefined":
         case "undefined1":
         case "byte":
-        case "bool":
             return "u8";
         case "undefined2":
         case "ushort":


### PR DESCRIPTION
The mapping will now have `bools` as-is instead of turning them into u8. This can lead to subtle differences in codegen.