### PR TITLE
Implement remaining SoundPlayer methods

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -226,6 +226,7 @@ th06::SoundPlayer::LoadSound
 th06::SoundPlayer::PlayBGM
 th06::SoundPlayer::StopBGM
 th06::SoundPlayer::PlaySounds
+th06::SoundPlayer::PlaySoundByIdx
 th06::SoundPlayer::BackgroundMusicPlayerThread
 th06::SoundPlayer::InitSoundBuffers
 th06::Player::AddedCallback

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -221,6 +221,7 @@ th06::utils::AddNormalizeAngle
 th06::SoundPlayer::SoundPlayer
 th06::SoundPlayer::InitializeDSound
 th06::SoundPlayer::LoadWav
+th06::SoundPlayer::LoadPos
 th06::SoundPlayer::GetWavFormatData
 th06::SoundPlayer::LoadSound
 th06::SoundPlayer::PlayBGM

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -226,6 +226,7 @@ th06::SoundPlayer::GetWavFormatData
 th06::SoundPlayer::LoadSound
 th06::SoundPlayer::PlayBGM
 th06::SoundPlayer::StopBGM
+th06::SoundPlayer::FadeOut
 th06::SoundPlayer::PlaySounds
 th06::SoundPlayer::PlaySoundByIdx
 th06::SoundPlayer::BackgroundMusicPlayerThread

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -220,6 +220,7 @@ th06::ScreenEffect::SetViewport
 th06::utils::AddNormalizeAngle
 th06::SoundPlayer::SoundPlayer
 th06::SoundPlayer::InitializeDSound
+th06::SoundPlayer::Release
 th06::SoundPlayer::LoadWav
 th06::SoundPlayer::LoadPos
 th06::SoundPlayer::GetWavFormatData

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -16,7 +16,6 @@ th06::MidiOutput::UnprepareHeader
 th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
 th06::MidiOutput::LoadFile
-th06::SoundPlayer::Release
 th06::ResultScreen::OpenScore
 th06::ResultScreen::ParseClrd
 th06::ResultScreen::ParsePscr

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -16,7 +16,6 @@ th06::MidiOutput::UnprepareHeader
 th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
 th06::MidiOutput::LoadFile
-th06::SoundPlayer::PlaySoundByIdx
 th06::SoundPlayer::Release
 th06::SoundPlayer::LoadPos
 th06::ResultScreen::OpenScore

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -17,7 +17,6 @@ th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
 th06::MidiOutput::LoadFile
 th06::SoundPlayer::Release
-th06::SoundPlayer::LoadPos
 th06::ResultScreen::OpenScore
 th06::ResultScreen::ParseClrd
 th06::ResultScreen::ParsePscr

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -125,6 +125,21 @@ void SoundPlayer::StopBGM()
     return;
 }
 
+#pragma optimize("s", on)
+void SoundPlayer::FadeOut(f32 seconds)
+{
+    CStreamingSound *bgm;
+
+    if(this->backgroundMusic != NULL)
+    {
+        bgm = this->backgroundMusic;
+        bgm->m_dwIsFadingOut = 1;
+        bgm->m_dwCurFadeoutProgress = seconds * 60;
+        bgm->m_dwTotalFadeout = bgm->m_dwCurFadeoutProgress;
+    }
+}
+#pragma optimize("", on)
+
 #pragma var_order(notifySize, waveFile, res, numSamplesPerSec, blockAlign, curTime, startTime, waitTime, curTime2,     \
                   startTime2, waitTime2)
 ZunResult SoundPlayer::LoadWav(char *path)

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -14,14 +14,12 @@ namespace th06
 #define BACKGROUND_MUSIC_WAV_BLOCK_ALIGN BACKGROUND_MUSIC_WAV_BITS_PER_SAMPLE / 8 * BACKGROUND_MUSIC_WAV_NUM_CHANNELS
 
 DIFFABLE_STATIC_ARRAY_ASSIGN(SoundBufferIdxVolume, 32, g_SoundBufferIdxVol) = {
-    {0, -1500, 0},   {0, -2000, 0},   {1, -1200, 5},   {1, -1400, 5}, 
-    {2, -1000, 100}, {3, -500, 100},  {4, -500, 100},  {5, -1700, 50}, 
-    {6, -1700, 50},  {7, -1700, 50},  {8, -1000, 100}, {9, -1000, 100}, 
-    {10, -1900, 10}, {11, -1200, 10}, {12, -900, 100}, {5, -1500, 50}, 
-    {13, -900, 50},  {14, -900, 50},  {15, -600, 100}, {16, -400, 100}, 
-    {17, -1100, 0},  {18, -900, 0},   {5, -1800, 20},  {6, -1800, 20}, 
-    {7, -1800, 20},  {19, -300, 50},  {20, -600, 50},  {21, -800, 50}, 
-    {22, -100, 140}, {23, -500, 100}, {24, -1000, 20}, {25, -1000, 90},
+    {0, -1500, 0},   {0, -2000, 0},   {1, -1200, 5},   {1, -1400, 5},  {2, -1000, 100}, {3, -500, 100},
+    {4, -500, 100},  {5, -1700, 50},  {6, -1700, 50},  {7, -1700, 50}, {8, -1000, 100}, {9, -1000, 100},
+    {10, -1900, 10}, {11, -1200, 10}, {12, -900, 100}, {5, -1500, 50}, {13, -900, 50},  {14, -900, 50},
+    {15, -600, 100}, {16, -400, 100}, {17, -1100, 0},  {18, -900, 0},  {5, -1800, 20},  {6, -1800, 20},
+    {7, -1800, 20},  {19, -300, 50},  {20, -600, 50},  {21, -800, 50}, {22, -100, 140}, {23, -500, 100},
+    {24, -1000, 20}, {25, -1000, 90},
 };
 DIFFABLE_STATIC_ARRAY_ASSIGN(char *, 26, g_SFXList) = {
     "data/wav/plst00.wav", "data/wav/enep00.wav",   "data/wav/pldead00.wav", "data/wav/power0.wav",
@@ -100,21 +98,22 @@ ZunResult SoundPlayer::InitializeDSound(HWND gameWindow)
     return ZUN_SUCCESS;
 }
 
-ZunResult SoundPlayer::Release(void) {
+ZunResult SoundPlayer::Release(void)
+{
     i32 i;
-    
-    if(this->manager == NULL)
+
+    if (this->manager == NULL)
     {
         return ZUN_SUCCESS;
     }
-    for(i = 0; i < 0x80; i++)
+    for (i = 0; i < 0x80; i++)
     {
-        if(this->duplicateSoundBuffers[i] != NULL)
+        if (this->duplicateSoundBuffers[i] != NULL)
         {
             this->duplicateSoundBuffers[i]->Release();
             this->duplicateSoundBuffers[i] = NULL;
         }
-        if(this->soundBuffers[i] != NULL)
+        if (this->soundBuffers[i] != NULL)
         {
             this->soundBuffers[i]->Release();
             this->soundBuffers[i] = NULL;
@@ -124,17 +123,17 @@ ZunResult SoundPlayer::Release(void) {
     StopBGM();
     this->dsoundHdl = NULL;
     this->initSoundBuffer->Stop();
-    if(this->initSoundBuffer != NULL)
+    if (this->initSoundBuffer != NULL)
     {
         this->initSoundBuffer->Release();
         this->initSoundBuffer = NULL;
     }
-    if(this->backgroundMusic != NULL)
+    if (this->backgroundMusic != NULL)
     {
         delete this->backgroundMusic;
         this->backgroundMusic = NULL;
     }
-    if(this->manager != NULL)
+    if (this->manager != NULL)
     {
         delete this->manager;
         this->manager = NULL;
@@ -172,7 +171,7 @@ void SoundPlayer::FadeOut(f32 seconds)
 {
     CStreamingSound *bgm;
 
-    if(this->backgroundMusic != NULL)
+    if (this->backgroundMusic != NULL)
     {
         bgm = this->backgroundMusic;
         bgm->m_dwIsFadingOut = 1;
@@ -266,22 +265,22 @@ ZunResult SoundPlayer::LoadPos(char *path)
     CWaveFile *bgmFile;
     i32 loopEnd;
     i32 loopStart;
-    
-    if(this->manager == NULL)
+
+    if (this->manager == NULL)
     {
         return ZUN_ERROR;
     }
-    if(g_Supervisor.cfg.playSounds == NULL)
+    if (g_Supervisor.cfg.playSounds == NULL)
     {
         return ZUN_ERROR;
     }
-    if(this->backgroundMusic == NULL)
+    if (this->backgroundMusic == NULL)
     {
         return ZUN_ERROR;
     }
-    
+
     fileData = FileSystem::OpenPath(path, 0);
-    if(fileData == NULL)
+    if (fileData == NULL)
     {
         return ZUN_ERROR;
     }
@@ -513,16 +512,16 @@ void SoundPlayer::PlaySoundByIdx(SoundIdx idx, i32 unused)
     SFXToPlay = g_SoundBufferIdxVol[idx].unk;
     for (i = 0; i < 3; i++)
     {
-        if(this->soundBuffersToPlay[i] < 0)
+        if (this->soundBuffersToPlay[i] < 0)
         {
             break;
         }
-        if(this->soundBuffersToPlay[i] == idx)
+        if (this->soundBuffersToPlay[i] == idx)
         {
             return;
         }
     }
-    if(i >= 3)
+    if (i >= 3)
     {
         return;
     }

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -100,6 +100,48 @@ ZunResult SoundPlayer::InitializeDSound(HWND gameWindow)
     return ZUN_SUCCESS;
 }
 
+ZunResult SoundPlayer::Release(void) {
+    i32 i;
+    
+    if(this->manager == NULL)
+    {
+        return ZUN_SUCCESS;
+    }
+    for(i = 0; i < 0x80; i++)
+    {
+        if(this->duplicateSoundBuffers[i] != NULL)
+        {
+            this->duplicateSoundBuffers[i]->Release();
+            this->duplicateSoundBuffers[i] = NULL;
+        }
+        if(this->soundBuffers[i] != NULL)
+        {
+            this->soundBuffers[i]->Release();
+            this->soundBuffers[i] = NULL;
+        }
+    }
+    KillTimer(this->gameWindow, 1);
+    StopBGM();
+    this->dsoundHdl = NULL;
+    this->initSoundBuffer->Stop();
+    if(this->initSoundBuffer != NULL)
+    {
+        this->initSoundBuffer->Release();
+        this->initSoundBuffer = NULL;
+    }
+    if(this->backgroundMusic != NULL)
+    {
+        delete this->backgroundMusic;
+        this->backgroundMusic = NULL;
+    }
+    if(this->manager != NULL)
+    {
+        delete this->manager;
+        this->manager = NULL;
+    }
+    return ZUN_SUCCESS;
+}
+
 void SoundPlayer::StopBGM()
 {
     if (this->backgroundMusic != NULL)

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -202,6 +202,41 @@ ZunResult SoundPlayer::LoadWav(char *path)
     return ZUN_SUCCESS;
 }
 
+#pragma var_order(fileData, bgmFile, loopEnd, loopStart)
+ZunResult SoundPlayer::LoadPos(char *path)
+{
+    u8 *fileData;
+    CWaveFile *bgmFile;
+    i32 loopEnd;
+    i32 loopStart;
+    
+    if(this->manager == NULL)
+    {
+        return ZUN_ERROR;
+    }
+    if(g_Supervisor.cfg.playSounds == NULL)
+    {
+        return ZUN_ERROR;
+    }
+    if(this->backgroundMusic == NULL)
+    {
+        return ZUN_ERROR;
+    }
+    
+    fileData = FileSystem::OpenPath(path, 0);
+    if(fileData == NULL)
+    {
+        return ZUN_ERROR;
+    }
+    bgmFile = this->backgroundMusic->m_pWaveFile;
+    loopEnd = *(i32 *)(fileData + 4) * 4;
+    loopStart = *(i32 *)(fileData) * 4;
+    bgmFile->m_loopStartPoint = loopStart;
+    bgmFile->m_loopEndPoint = loopEnd;
+    free(fileData);
+    return ZUN_SUCCESS;
+}
+
 ZunResult SoundPlayer::InitSoundBuffers()
 {
     i32 idx;

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -13,7 +13,16 @@ namespace th06
 #define BACKGROUND_MUSIC_WAV_BITS_PER_SAMPLE 16
 #define BACKGROUND_MUSIC_WAV_BLOCK_ALIGN BACKGROUND_MUSIC_WAV_BITS_PER_SAMPLE / 8 * BACKGROUND_MUSIC_WAV_NUM_CHANNELS
 
-DIFFABLE_STATIC(SoundBufferIdxVolume, g_SoundBufferIdxVol[32]);
+DIFFABLE_STATIC_ARRAY_ASSIGN(SoundBufferIdxVolume, 32, g_SoundBufferIdxVol) = {
+    {0, -1500, 0},   {0, -2000, 0},   {1, -1200, 5},   {1, -1400, 5}, 
+    {2, -1000, 100}, {3, -500, 100},  {4, -500, 100},  {5, -1700, 50}, 
+    {6, -1700, 50},  {7, -1700, 50},  {8, -1000, 100}, {9, -1000, 100}, 
+    {10, -1900, 10}, {11, -1200, 10}, {12, -900, 100}, {5, -1500, 50}, 
+    {13, -900, 50},  {14, -900, 50},  {15, -600, 100}, {16, -400, 100}, 
+    {17, -1100, 0},  {18, -900, 0},   {5, -1800, 20},  {6, -1800, 20}, 
+    {7, -1800, 20},  {19, -300, 50},  {20, -600, 50},  {21, -800, 50}, 
+    {22, -100, 140}, {23, -500, 100}, {24, -1000, 20}, {25, -1000, 90},
+};
 DIFFABLE_STATIC_ARRAY_ASSIGN(char *, 26, g_SFXList) = {
     "data/wav/plst00.wav", "data/wav/enep00.wav",   "data/wav/pldead00.wav", "data/wav/power0.wav",
     "data/wav/power1.wav", "data/wav/tan00.wav",    "data/wav/tan01.wav",    "data/wav/tan02.wav",
@@ -400,6 +409,33 @@ void SoundPlayer::PlaySounds()
         this->duplicateSoundBuffers[sndBufIdx]->SetCurrentPosition(0);
         this->duplicateSoundBuffers[sndBufIdx]->Play(0, 0, 0);
     }
+    return;
+}
+
+#pragma var_order(i, SFXToPlay)
+void SoundPlayer::PlaySoundByIdx(SoundIdx idx, i32 unused)
+{
+    i32 SFXToPlay;
+    i32 i;
+
+    SFXToPlay = g_SoundBufferIdxVol[idx].unk;
+    for (i = 0; i < 3; i++)
+    {
+        if(this->soundBuffersToPlay[i] < 0)
+        {
+            break;
+        }
+        if(this->soundBuffersToPlay[i] == idx)
+        {
+            return;
+        }
+    }
+    if(i >= 3)
+    {
+        return;
+    }
+    this->soundBuffersToPlay[i] = idx;
+    this->unk408[idx] = SFXToPlay;
     return;
 }
 

--- a/src/SoundPlayer.hpp
+++ b/src/SoundPlayer.hpp
@@ -69,6 +69,7 @@ struct SoundPlayer
     void PlaySoundByIdx(SoundIdx idx, i32 unused);
     ZunResult PlayBGM(BOOL isLooping);
     void StopBGM();
+    void FadeOut(f32 seconds);
 
     static DWORD __stdcall BackgroundMusicPlayerThread(LPVOID lpThreadParameter);
 

--- a/src/zwave.hpp
+++ b/src/zwave.hpp
@@ -87,11 +87,13 @@ class CSound
   protected:
     DWORD m_dwNumBuffers;
 
+  public:
     // th06 extensions for fadeout
     i32 m_dwCurFadeoutProgress;
     i32 m_dwTotalFadeout;
     DWORD m_dwIsFadingOut;
 
+  protected:
     HRESULT RestoreBuffer(LPDIRECTSOUNDBUFFER pDSB, BOOL *pbWasRestored);
 
   public:

--- a/src/zwave.hpp
+++ b/src/zwave.hpp
@@ -80,7 +80,11 @@ class CSound
   protected:
     LPDIRECTSOUNDBUFFER *m_apDSBuffer;
     DWORD m_dwDSBufferSize;
+
+  public:
     CWaveFile *m_pWaveFile;
+
+  protected:
     DWORD m_dwNumBuffers;
 
     // th06 extensions for fadeout


### PR DESCRIPTION
Implement `SoundPlayer::FadeOut`, `SoundPlayer::Release`, `SoundPlayer::LoadPos`, and `SoundPlayer::PlaySoundByIdx`. Everything except `PlaySoundByIdx` compiles to a 100% match and `PlaySoundByIdx` only differs in one instruction where the original code uses a slightly different method to calculate a pointer. These implementations allow sound effects to work and fix the looping of music.