### PR TITLE
Implementes effects update callbacks

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -94,6 +94,7 @@ th06::EffectManager::SpawnParticles
 th06::EffectManager::EffectCallbackRandomSplash
 th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EffectManager::EffectCallbackStill
+th06::EffectManager::EffectUpdateCallback4
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -95,6 +95,7 @@ th06::EffectManager::EffectCallbackRandomSplash
 th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EffectManager::EffectCallbackStill
 th06::EffectManager::EffectUpdateCallback4
+th06::EffectManager::EffectCallbackAttract
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -93,6 +93,7 @@ th06::EffectManager::OnDraw
 th06::EffectManager::SpawnParticles
 th06::EffectManager::EffectCallbackRandomSplash
 th06::EffectManager::EffectCallbackRandomSplashBig
+th06::EffectManager::EffectCallbackStill
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -91,6 +91,7 @@ th06::EffectManager::CutChain
 th06::EffectManager::OnUpdate
 th06::EffectManager::OnDraw
 th06::EffectManager::SpawnParticles
+th06::EffectManager::EffectCallbackRandomSplash
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -96,6 +96,7 @@ th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EffectManager::EffectCallbackStill
 th06::EffectManager::EffectUpdateCallback4
 th06::EffectManager::EffectCallbackAttract
+th06::EffectManager::EffectCallbackAttractSlow
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -92,6 +92,7 @@ th06::EffectManager::OnUpdate
 th06::EffectManager::OnDraw
 th06::EffectManager::SpawnParticles
 th06::EffectManager::EffectCallbackRandomSplash
+th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EnemyManager::Initialize
 th06::EnemyManager::RegisterChain
 th06::EnemyManager::CutChain

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectCallbackAttract
 th06::EffectManager::EffectCallbackAttractSlow
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectUpdateCallback4
 th06::EffectManager::EffectCallbackAttract
 th06::EffectManager::EffectCallbackAttractSlow
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectCallbackRandomSplash
 th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EffectManager::EffectCallbackStill
 th06::EffectManager::EffectUpdateCallback4

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectCallbackStill
 th06::EffectManager::EffectUpdateCallback4
 th06::EffectManager::EffectCallbackAttract
 th06::EffectManager::EffectCallbackAttractSlow

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectCallbackAttractSlow
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing
 th06::MidiDevice::Close

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,5 +1,4 @@
 th06::EclManager::Unload
-th06::EffectManager::EffectCallbackRandomSplashBig
 th06::EffectManager::EffectCallbackStill
 th06::EffectManager::EffectUpdateCallback4
 th06::EffectManager::EffectCallbackAttract

--- a/src/BulletManager.cpp
+++ b/src/BulletManager.cpp
@@ -130,14 +130,14 @@ u32 BulletManager::SpawnSingleBullet(EnemyBulletShooter *bulletProps, i32 bullet
     case CIRCLE_AIMED:
         bulletAngle += angle;
     case CIRCLE:
-        bulletAngle += bulletIdx1 * (ZUN_PI * 2.0f) / bulletProps->count1;
+        bulletAngle += bulletIdx1 * ZUN_2PI / bulletProps->count1;
         bulletAngle += bulletIdx2 * bulletProps->angle2 + bulletProps->angle1;
         break;
     case OFFSET_CIRCLE_AIMED:
         bulletAngle += angle;
     case OFFSET_CIRCLE:
         bulletAngle += ZUN_PI / bulletProps->count1;
-        bulletAngle += bulletIdx1 * (ZUN_PI * 2.0f) / bulletProps->count1;
+        bulletAngle += bulletIdx1 * ZUN_2PI / bulletProps->count1;
         bulletAngle += bulletProps->angle1;
         break;
     case RANDOM_ANGLE:
@@ -145,7 +145,7 @@ u32 BulletManager::SpawnSingleBullet(EnemyBulletShooter *bulletProps, i32 bullet
         break;
     case RANDOM_SPEED:
         bulletSpeed = g_Rng.GetRandomF32InRange(bulletProps->speed1 - bulletProps->speed2) + bulletProps->speed2;
-        bulletAngle += bulletIdx1 * (ZUN_PI * 2.0f) / bulletProps->count1;
+        bulletAngle += bulletIdx1 * ZUN_2PI / bulletProps->count1;
         bulletAngle += bulletIdx2 * bulletProps->angle2 + bulletProps->angle1;
         break;
     case RANDOM:

--- a/src/Effect.hpp
+++ b/src/Effect.hpp
@@ -6,6 +6,12 @@
 
 namespace th06
 {
+enum EffectCallbackResult
+{
+    EFFECT_CALLBACK_RESULT_STOP = 0,
+    EFFECT_CALLBACK_RESULT_DONE = 1
+};
+
 struct Effect;
 
 typedef i32 (*EffectUpdateCallback)(Effect *);

--- a/src/Effect.hpp
+++ b/src/Effect.hpp
@@ -13,12 +13,8 @@ struct Effect
 {
     AnmVm vm;
     D3DXVECTOR3 pos1;
-    f32 unk_11c;
-    f32 unk_120;
-    f32 unk_124;
-    f32 unk_128;
-    f32 unk_12c;
-    f32 unk_130;
+    D3DXVECTOR3 unk_11c;
+    D3DXVECTOR3 unk_128;
     D3DXVECTOR3 position;
     D3DXVECTOR3 pos2;
     D3DXQUATERNION quaternion;

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -270,4 +270,61 @@ i32 EffectManager::EffectCallbackStill(Effect *effect)
     return 1;
 }
 
+#pragma var_order(posOffset, verticalAngle, local_54, horizontalAngle, normalizedPos, alpha)
+i32 EffectManager::EffectUpdateCallback4(Effect *effect)
+{
+    D3DXVECTOR3 posOffset;
+    f32 verticalAngle;
+
+    D3DXMATRIX local_54;
+    f32 horizontalAngle;
+    D3DXVECTOR3 normalizedPos;
+    f32 alpha;
+
+    D3DXVec3Normalize(&normalizedPos, &effect->pos2);
+
+    verticalAngle = sinf(effect->angleRelated);
+    horizontalAngle = cosf(effect->angleRelated);
+
+    effect->quaternion.x = normalizedPos.x * verticalAngle;
+    effect->quaternion.y = normalizedPos.y * verticalAngle;
+    effect->quaternion.z = normalizedPos.z * verticalAngle;
+    effect->quaternion.w = horizontalAngle;
+    D3DXMatrixRotationQuaternion(&local_54, &effect->quaternion);
+
+    posOffset.x = normalizedPos.y * 1.0f - normalizedPos.z * 0.0f;
+    posOffset.y = normalizedPos.z * 0.0f - normalizedPos.x * 1.0f;
+    posOffset.z = normalizedPos.x * 0.0f - normalizedPos.y * 0.0f;
+
+    if (D3DXVec3LengthSq(&posOffset) < 0)
+    {
+        normalizedPos = D3DXVECTOR3(1.0f, 0.0f, 0.0f);
+    }
+    else
+    {
+        D3DXVec3Normalize(&posOffset, &posOffset);
+    }
+
+    posOffset *= effect->unk_15c;
+    D3DXVec3TransformCoord(&posOffset, &posOffset, &local_54);
+    posOffset.z *= 6.0f;
+
+    effect->pos1 = posOffset + effect->position;
+    if (effect->unk_17a)
+    {
+        effect->unk_17b++;
+        if (effect->unk_17b >= 16)
+        {
+            return 0;
+        }
+
+        alpha = 1.0f - effect->unk_17b / 16.0f;
+        effect->vm.color = COLOR_SET_ALPHA3(effect->vm.color, (i32)(alpha * 255.0f));
+
+        effect->vm.scaleY = 2.0f - alpha;
+        effect->vm.scaleX = effect->vm.scaleY;
+    }
+    return 1;
+}
+
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -247,4 +247,20 @@ i32 EffectManager::EffectCallbackRandomSplash(Effect *effect)
     return 1;
 }
 
+i32 EffectManager::EffectCallbackRandomSplashBig(Effect *effect)
+{
+    if (effect->timer == 0 && effect->timer.HasTicked())
+    {
+        effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 256.0f - 128.0f) * 4.0f / 33.0f;
+        effect->unk_11c.y = (g_Rng.GetRandomF32ZeroToOne() * 256.0f - 128.0f) * 4.0f / 33.0f;
+        effect->unk_11c.z = 0.0f;
+
+        effect->unk_128 = -effect->unk_11c / 20.0f;
+    }
+
+    effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
+    effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+    return 1;
+}
+
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -327,4 +327,23 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
     return 1;
 }
 
+i32 EffectManager::EffectCallbackAttract(Effect *effect)
+{
+    f32 angle;
+
+    if (effect->timer == 0 && effect->timer.HasTicked())
+    {
+        effect->position = effect->pos1;
+
+        angle = g_Rng.GetRandomF32ZeroToOne() * ZUN_2PI - ZUN_PI;
+        effect->pos2.x = cosf(angle);
+        effect->pos2.y = sinf(angle);
+        effect->pos2.z = 0.0;
+    }
+    angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 60.0f;
+
+    effect->pos1 = angle * effect->pos2 + effect->position;
+    return 1;
+}
+
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -263,4 +263,11 @@ i32 EffectManager::EffectCallbackRandomSplashBig(Effect *effect)
     return 1;
 }
 
+i32 EffectManager::EffectCallbackStill(Effect *effect)
+{
+    effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
+    effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+    return 1;
+}
+
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -144,7 +144,7 @@ ChainCallbackResult EffectManager::OnUpdate(EffectManager *mgr)
             continue;
         }
         mgr->activeEffects++;
-        if (effect->updateCallback != NULL && (effect->updateCallback)(effect) != 1)
+        if (effect->updateCallback != NULL && (effect->updateCallback)(effect) != EFFECT_CALLBACK_RESULT_DONE)
         {
             effect->inUseFlag = 0;
         }
@@ -244,7 +244,7 @@ i32 EffectManager::EffectCallbackRandomSplash(Effect *effect)
 
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 i32 EffectManager::EffectCallbackRandomSplashBig(Effect *effect)
@@ -260,14 +260,14 @@ i32 EffectManager::EffectCallbackRandomSplashBig(Effect *effect)
 
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 i32 EffectManager::EffectCallbackStill(Effect *effect)
 {
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 #pragma var_order(posOffset, verticalAngle, local_54, horizontalAngle, normalizedPos, alpha)
@@ -315,7 +315,7 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
         effect->unk_17b++;
         if (effect->unk_17b >= 16)
         {
-            return 0;
+            return EFFECT_CALLBACK_RESULT_STOP;
         }
 
         alpha = 1.0f - effect->unk_17b / 16.0f;
@@ -324,7 +324,7 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
         effect->vm.scaleY = 2.0f - alpha;
         effect->vm.scaleX = effect->vm.scaleY;
     }
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 i32 EffectManager::EffectCallbackAttract(Effect *effect)
@@ -343,7 +343,7 @@ i32 EffectManager::EffectCallbackAttract(Effect *effect)
     angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 60.0f;
 
     effect->pos1 = angle * effect->pos2 + effect->position;
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 i32 EffectManager::EffectCallbackAttractSlow(Effect *effect)
@@ -362,7 +362,7 @@ i32 EffectManager::EffectCallbackAttractSlow(Effect *effect)
     angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 240.0f;
 
     effect->pos1 = angle * effect->pos2 + effect->position;
-    return 1;
+    return EFFECT_CALLBACK_RESULT_DONE;
 }
 
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -346,4 +346,23 @@ i32 EffectManager::EffectCallbackAttract(Effect *effect)
     return 1;
 }
 
+i32 EffectManager::EffectCallbackAttractSlow(Effect *effect)
+{
+    f32 angle;
+
+    if (effect->timer == 0 && effect->timer.HasTicked())
+    {
+        effect->position = effect->pos1;
+
+        angle = g_Rng.GetRandomF32ZeroToOne() * ZUN_2PI - ZUN_PI;
+        effect->pos2.x = cosf(angle);
+        effect->pos2.y = sinf(angle);
+        effect->pos2.z = 0.0;
+    }
+    angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 240.0f;
+
+    effect->pos1 = angle * effect->pos2 + effect->position;
+    return 1;
+}
+
 }; // namespace th06

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -42,21 +42,25 @@ ZunResult EffectManager::RegisterChain()
 {
     EffectManager *mgr = &g_EffectManager;
     mgr->Reset();
+
     g_EffectManagerCalcChain.callback = (ChainCallback)mgr->OnUpdate;
     g_EffectManagerCalcChain.addedCallback = NULL;
     g_EffectManagerCalcChain.deletedCallback = NULL;
     g_EffectManagerCalcChain.addedCallback = (ChainAddedCallback)mgr->AddedCallback;
     g_EffectManagerCalcChain.deletedCallback = (ChainAddedCallback)mgr->AddedCallback;
     g_EffectManagerCalcChain.arg = mgr;
+
     if (g_Chain.AddToCalcChain(&g_EffectManagerCalcChain, TH_CHAIN_PRIO_CALC_EFFECTMANAGER))
     {
         return ZUN_ERROR;
     }
+
     g_EffectManagerDrawChain.callback = (ChainCallback)mgr->OnDraw;
     g_EffectManagerDrawChain.addedCallback = NULL;
     g_EffectManagerDrawChain.deletedCallback = NULL;
     g_EffectManagerDrawChain.arg = mgr;
     g_Chain.AddToDrawChain(&g_EffectManagerDrawChain, TH_CHAIN_PRIO_DRAW_EFFECTMANAGER);
+
     return ZUN_SUCCESS;
 }
 
@@ -64,7 +68,6 @@ void EffectManager::CutChain()
 {
     g_Chain.Cut(&g_EffectManagerCalcChain);
     g_Chain.Cut(&g_EffectManagerDrawChain);
-    return;
 }
 
 ZunResult EffectManager::AddedCallback(EffectManager *mgr)
@@ -122,6 +125,7 @@ ZunResult EffectManager::AddedCallback(EffectManager *mgr)
 ZunResult EffectManager::DeletedCallback(EffectManager *p)
 {
     g_AnmManager->ReleaseAnm(ANM_FILE_EFFECTS);
+
     return ZUN_SUCCESS;
 }
 
@@ -143,17 +147,21 @@ ChainCallbackResult EffectManager::OnUpdate(EffectManager *mgr)
         {
             continue;
         }
+
         mgr->activeEffects++;
         if (effect->updateCallback != NULL && (effect->updateCallback)(effect) != EFFECT_CALLBACK_RESULT_DONE)
         {
             effect->inUseFlag = 0;
         }
+
         if (g_AnmManager->ExecuteScript(&effect->vm) != 0)
         {
             effect->inUseFlag = 0;
         }
+
         effect->timer.Tick();
     }
+
     return CHAIN_CALLBACK_RESULT_CONTINUE;
 }
 
@@ -169,9 +177,11 @@ ChainCallbackResult EffectManager::OnDraw(EffectManager *mgr)
         {
             continue;
         }
+
         effect->vm.pos = effect->pos1;
         g_AnmManager->Draw3(&effect->vm);
     }
+
     return CHAIN_CALLBACK_RESULT_CONTINUE;
 }
 
@@ -227,12 +237,12 @@ Effect *EffectManager::SpawnParticles(i32 effectIdx, D3DXVECTOR3 *pos, i32 count
             effect++;
         }
     }
+
     return idx >= ARRAY_SIZE_SIGNED(this->effects) ? &this->dummyEffect : effect;
 }
 
 i32 EffectManager::EffectCallbackRandomSplash(Effect *effect)
 {
-
     if (effect->timer == 0 && effect->timer.HasTicked())
     {
         effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 256.0f - 128.0f) / 12.0f;
@@ -244,6 +254,7 @@ i32 EffectManager::EffectCallbackRandomSplash(Effect *effect)
 
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 
@@ -260,6 +271,7 @@ i32 EffectManager::EffectCallbackRandomSplashBig(Effect *effect)
 
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 
@@ -267,6 +279,7 @@ i32 EffectManager::EffectCallbackStill(Effect *effect)
 {
     effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
     effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 
@@ -275,7 +288,6 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
 {
     D3DXVECTOR3 posOffset;
     f32 verticalAngle;
-
     D3DXMATRIX local_54;
     f32 horizontalAngle;
     D3DXVECTOR3 normalizedPos;
@@ -310,9 +322,11 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
     posOffset.z *= 6.0f;
 
     effect->pos1 = posOffset + effect->position;
+
     if (effect->unk_17a)
     {
         effect->unk_17b++;
+
         if (effect->unk_17b >= 16)
         {
             return EFFECT_CALLBACK_RESULT_STOP;
@@ -324,6 +338,7 @@ i32 EffectManager::EffectUpdateCallback4(Effect *effect)
         effect->vm.scaleY = 2.0f - alpha;
         effect->vm.scaleX = effect->vm.scaleY;
     }
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 
@@ -340,9 +355,11 @@ i32 EffectManager::EffectCallbackAttract(Effect *effect)
         effect->pos2.y = sinf(angle);
         effect->pos2.z = 0.0;
     }
+
     angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 60.0f;
 
     effect->pos1 = angle * effect->pos2 + effect->position;
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 
@@ -359,9 +376,11 @@ i32 EffectManager::EffectCallbackAttractSlow(Effect *effect)
         effect->pos2.y = sinf(angle);
         effect->pos2.z = 0.0;
     }
+
     angle = 256.0f - effect->timer.AsFramesFloat() * 256.0f / 240.0f;
 
     effect->pos1 = angle * effect->pos2 + effect->position;
+
     return EFFECT_CALLBACK_RESULT_DONE;
 }
 

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -4,6 +4,7 @@
 #include "Chain.hpp"
 #include "ChainPriorities.hpp"
 #include "GameManager.hpp"
+#include "Rng.hpp"
 #include "ZunResult.hpp"
 #include "utils.hpp"
 
@@ -228,4 +229,22 @@ Effect *EffectManager::SpawnParticles(i32 effectIdx, D3DXVECTOR3 *pos, i32 count
     }
     return idx >= ARRAY_SIZE_SIGNED(this->effects) ? &this->dummyEffect : effect;
 }
+
+i32 EffectManager::EffectCallbackRandomSplash(Effect *effect)
+{
+
+    if (effect->timer == 0 && effect->timer.HasTicked())
+    {
+        effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 256.0f - 128.0f) / 12.0f;
+        effect->unk_11c.y = (g_Rng.GetRandomF32ZeroToOne() * 256.0f - 128.0f) / 12.0f;
+        effect->unk_11c.z = 0.0f;
+
+        effect->unk_128 = -effect->unk_11c / 19.0f;
+    }
+
+    effect->pos1 += effect->unk_11c * g_Supervisor.effectiveFramerateMultiplier;
+    effect->unk_11c += effect->unk_128 * g_Supervisor.effectiveFramerateMultiplier;
+    return 1;
+}
+
 }; // namespace th06

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1307,7 +1307,7 @@ void th06::Player::BombReimuACalc(Player *player)
             player->bombInfo.reimuABombProjectilesRelated[i] = 4.0f;
             player->bombInfo.bombRegionPositions[i] = player->positionCenter;
 
-            angle.x = g_Rng.GetRandomF32ZeroToOne() * (ZUN_PI * 2) - ZUN_PI;
+            angle.x = g_Rng.GetRandomF32ZeroToOne() * ZUN_2PI - ZUN_PI;
 
             player->bombInfo.bombRegionVelocities[i].x =
                 cosf(angle.x) * player->bombInfo.reimuABombProjectilesRelated[i];
@@ -1458,7 +1458,7 @@ void th06::Player::BombMarisaACalc(Player *player)
             g_AnmManager->ExecuteAnmIdx(starSprite, ANM_SCRIPT_PLAYER_MARISA_A_BLUE_STAR + i % 3);
             player->bombInfo.bombRegionPositions[i] = player->positionCenter;
 
-            starAngle = i * (ZUN_PI * 2) / 8.0f;
+            starAngle = i * ZUN_2PI / 8.0f;
 
             player->bombInfo.bombRegionVelocities[i].x = cosf(starAngle) * 2;
 

--- a/src/ZunMath.hpp
+++ b/src/ZunMath.hpp
@@ -49,6 +49,7 @@ C_ASSERT(sizeof(ZunVec3) == 0xC);
 
 #define ZUN_MIN(x, y) ((x) > (y) ? (y) : (x))
 #define ZUN_PI ((f32)(3.14159265358979323846))
+#define ZUN_2PI ((f32)(ZUN_PI * 2.0f))
 
 #define RADIANS(degrees) ((degrees * ZUN_PI / 180.0f))
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -53,13 +53,13 @@ f32 AddNormalizeAngle(f32 a, f32 b)
     a += b;
     while (a > ZUN_PI)
     {
-        a -= 2 * ZUN_PI;
+        a -= ZUN_2PI;
         if (i++ > 16)
             break;
     }
     while (a < -ZUN_PI)
     {
-        a += 2 * ZUN_PI;
+        a += ZUN_2PI;
         if (i++ > 16)
             break;
     }


### PR DESCRIPTION
Implements and matches:
- `th06::EffectManager::EffectUpdateCallback1`(Renamed to `EffectCallbackRandomSplash`)
- `th06::EffectManager::EffectUpdateCallback2`(Renamed to `EffectCallbackRandomSplashBig`)
- `th06::EffectManager::EffectUpdateCallback3`(Renamed to `EffectCallbackStill`)
- `th06::EffectManager::EffectUpdateCallback4`
- `th06::EffectManager::EffectUpdateCallback5`(Renamed to `EffectCallbackAttract`)
- `th06::EffectManager::EffectUpdateCallback6`(Renamed to `EffectCallbackAttractSlow`)

`EffectUpdateCallback4` definitely needs some documentation, but i really don't wanna relearn matrixes again...