### PR TITLE
Implement remaining non-MIDI sound functionality

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -219,6 +219,7 @@ th06::Supervisor::OnUpdate
 th06::Supervisor::OnDraw
 th06::Supervisor::TickTimer
 th06::Supervisor::SetupDInput
+th06::Supervisor::ReadMidiFile
 th06::Supervisor::PlayMidiFile
 th06::Supervisor::PlayAudio
 th06::Supervisor::StopAudio

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -219,6 +219,7 @@ th06::Supervisor::OnUpdate
 th06::Supervisor::OnDraw
 th06::Supervisor::TickTimer
 th06::Supervisor::SetupDInput
+th06::Supervisor::PlayMidiFile
 th06::Supervisor::PlayAudio
 th06::GameWindow::InitD3dDevice
 th06::GameWindow::InitD3dRendering

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -221,6 +221,7 @@ th06::Supervisor::TickTimer
 th06::Supervisor::SetupDInput
 th06::Supervisor::PlayMidiFile
 th06::Supervisor::PlayAudio
+th06::Supervisor::FadeOutMusic
 th06::GameWindow::InitD3dDevice
 th06::GameWindow::InitD3dRendering
 th06::ScreenEffect::Clear

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -221,6 +221,7 @@ th06::Supervisor::TickTimer
 th06::Supervisor::SetupDInput
 th06::Supervisor::PlayMidiFile
 th06::Supervisor::PlayAudio
+th06::Supervisor::StopAudio
 th06::Supervisor::FadeOutMusic
 th06::GameWindow::InitD3dDevice
 th06::GameWindow::InitD3dRendering

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -223,6 +223,7 @@ th06::Supervisor::ReadMidiFile
 th06::Supervisor::PlayMidiFile
 th06::Supervisor::PlayAudio
 th06::Supervisor::StopAudio
+th06::Supervisor::SetupMidiPlayback
 th06::Supervisor::FadeOutMusic
 th06::GameWindow::InitD3dDevice
 th06::GameWindow::InitD3dRendering

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -13,6 +13,7 @@ th06::MidiOutput::ClearTracks
 th06::MidiOutput::OnTimerElapsed
 th06::MidiOutput::StopPlayback
 th06::MidiOutput::UnprepareHeader
+th06::MidiOutput::ReadFileData
 th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
 th06::MidiOutput::ParseFile
@@ -25,7 +26,6 @@ th06::ResultScreen::ParseCatk
 th06::ResultScreen::GetHighScore
 th06::Supervisor::DeletedCallback
 th06::Supervisor::SetupMidiPlayback
-th06::Supervisor::ReadMidiFile
 th06::Ending::RegisterChain
 th06::MusicRoom::RegisterChain
 th06::ResultScreen::RegisterChain

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -24,7 +24,6 @@ th06::ResultScreen::ParsePscr
 th06::ResultScreen::ParseCatk
 th06::ResultScreen::GetHighScore
 th06::Supervisor::DeletedCallback
-th06::Supervisor::StopAudio
 th06::Supervisor::SetupMidiPlayback
 th06::Supervisor::ReadMidiFile
 th06::Ending::RegisterChain

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -17,6 +17,7 @@ th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
 th06::MidiOutput::ParseFile
 th06::MidiOutput::LoadFile
+th06::MidiOutput::SetFadeOut
 th06::ResultScreen::OpenScore
 th06::ResultScreen::ParseClrd
 th06::ResultScreen::ParsePscr
@@ -26,7 +27,6 @@ th06::Supervisor::DeletedCallback
 th06::Supervisor::StopAudio
 th06::Supervisor::SetupMidiPlayback
 th06::Supervisor::ReadMidiFile
-th06::Supervisor::FadeOutMusic
 th06::Ending::RegisterChain
 th06::MusicRoom::RegisterChain
 th06::ResultScreen::RegisterChain

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -15,6 +15,7 @@ th06::MidiOutput::StopPlayback
 th06::MidiOutput::UnprepareHeader
 th06::MidiOutput::ReleaseFileData
 th06::MidiOutput::Play
+th06::MidiOutput::ParseFile
 th06::MidiOutput::LoadFile
 th06::ResultScreen::OpenScore
 th06::ResultScreen::ParseClrd
@@ -25,7 +26,6 @@ th06::Supervisor::DeletedCallback
 th06::Supervisor::StopAudio
 th06::Supervisor::SetupMidiPlayback
 th06::Supervisor::ReadMidiFile
-th06::Supervisor::PlayMidiFile
 th06::Supervisor::FadeOutMusic
 th06::Ending::RegisterChain
 th06::MusicRoom::RegisterChain

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -25,7 +25,6 @@ th06::ResultScreen::ParsePscr
 th06::ResultScreen::ParseCatk
 th06::ResultScreen::GetHighScore
 th06::Supervisor::DeletedCallback
-th06::Supervisor::SetupMidiPlayback
 th06::Ending::RegisterChain
 th06::MusicRoom::RegisterChain
 th06::ResultScreen::RegisterChain

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -314,9 +314,9 @@ ZunResult GameManager::AddedCallback(GameManager *mgr)
     if (g_GameManager.demoMode == 0)
     {
         // Read boss battle, and store it for use when boss is started.
-        g_Supervisor.ReadMidiFile(1, g_Stage.stdData->songPaths[2]);
+        g_Supervisor.ReadMidiFile(1, g_Stage.stdData->songPaths[1]);
         // Immediately start playing this level's theme.
-        g_Supervisor.PlayAudio(g_Stage.stdData->songPaths[1]);
+        g_Supervisor.PlayAudio(g_Stage.stdData->songPaths[0]);
     }
     mgr->isInRetryMenu = 0;
     mgr->isInMenu = 1;

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -62,6 +62,8 @@ struct MidiOutput : MidiTimer
     ZunResult LoadFile(char *midiPath);
     ZunResult Play();
 
+    void SetFadeOut(u32 ms);
+
     MIDIHDR *midiHeaders[32];
     i32 midiHeadersCursor;
     u8 *midiFileData[32];

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -53,9 +53,9 @@ struct MidiOutput : MidiTimer
     void OnTimerElapsed();
 
     ZunResult UnprepareHeader(LPMIDIHDR param_1);
-
     ZunResult StopPlayback();
     void ClearTracks();
+    ZunResult ReadFileData(u32 idx, char *path);
     void ReleaseFileData(u32 idx);
 
     void ParseFile(i32 idx);

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -58,6 +58,7 @@ struct MidiOutput : MidiTimer
     void ClearTracks();
     void ReleaseFileData(u32 idx);
 
+    void ParseFile(i32 idx);
     ZunResult LoadFile(char *midiPath);
     ZunResult Play();
 

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -346,8 +346,8 @@ WAVEFORMATEX *SoundPlayer::GetWavFormatData(u8 *soundData, char *formatString, i
     return NULL;
 }
 
-#pragma var_order(fileSize, soundFileData, audioPtr1, audioSize1, audioPtr2, audioSize2, formatSize, wavDataPtr,       \
-                  dsBuffer, wavData, sFDCursor)
+#pragma var_order(sFDCursor, dsBuffer, wavDataPtr, formatSize, audioPtr2, audioSize2, audioSize1, audioPtr1,       \
+                  soundFileData, wavData, fileSize)
 ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
 {
     u8 *soundFileData;
@@ -373,7 +373,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
     }
     soundFileData = (u8 *)FileSystem::OpenPath(path, 0);
     sFDCursor = soundFileData;
-    if (soundFileData == NULL)
+    if (sFDCursor == NULL)
     {
         return ZUN_ERROR;
     }
@@ -428,7 +428,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
         return ZUN_ERROR;
     }
     memcpy(audioPtr1, wavDataPtr, audioSize1);
-    if (audioPtr2 != NULL)
+    if (audioSize2 != 0)
     {
         memcpy(audioPtr2, (i8 *)wavDataPtr + audioSize1, audioSize2);
     }

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -346,7 +346,7 @@ WAVEFORMATEX *SoundPlayer::GetWavFormatData(u8 *soundData, char *formatString, i
     return NULL;
 }
 
-#pragma var_order(sFDCursor, dsBuffer, wavDataPtr, formatSize, audioPtr2, audioSize2, audioSize1, audioPtr1,       \
+#pragma var_order(sFDCursor, dsBuffer, wavDataPtr, formatSize, audioPtr2, audioSize2, audioSize1, audioPtr1,           \
                   soundFileData, wavData, fileSize)
 ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
 {

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1110,4 +1110,48 @@ ZunResult Supervisor::PlayAudio(char *path)
     return ZUN_SUCCESS;
 }
 #pragma optimize("", on)
+
+#pragma optimize("s", on)
+ZunResult Supervisor::FadeOutMusic(f32 fadeOutSeconds)
+{
+    i32 unused1;
+    i32 unused2;
+    i32 unused3;
+
+    if (g_Supervisor.cfg.musicMode == MIDI)
+    {
+        if (g_Supervisor.midiOutput != NULL)
+        {
+            g_Supervisor.midiOutput->SetFadeOut(1000.0f * fadeOutSeconds);
+        }
+    }
+    else
+    {
+        if (g_Supervisor.cfg.musicMode == WAV)
+        {
+            if (this->effectiveFramerateMultiplier == 0.0f)
+            {
+                g_SoundPlayer.FadeOut(fadeOutSeconds);
+            }
+            else
+            {
+                if (this->effectiveFramerateMultiplier > 1.0f)
+                {
+                    g_SoundPlayer.FadeOut(fadeOutSeconds);                    
+                }
+                else
+                {
+                    g_SoundPlayer.FadeOut(fadeOutSeconds / this->effectiveFramerateMultiplier);
+                }
+            }
+        }
+        else
+        {
+            return ZUN_ERROR;
+        }
+    }
+
+    return ZUN_SUCCESS;
+}
+#pragma optimize("", on)
 }; // namespace th06

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1052,12 +1052,11 @@ ZunBool Supervisor::ReadMidiFile(u32 midiFileIdx, char *path)
         {
             g_Supervisor.midiOutput->ReadFileData(midiFileIdx, path);
         }
+
         return FALSE;
     }
-    else
-    {
-        return TRUE;
-    }
+
+    return TRUE;
 }
 #pragma optimize("", on)
 
@@ -1071,11 +1070,11 @@ i32 Supervisor::PlayMidiFile(i32 midiFileIdx)
         if (g_Supervisor.midiOutput != NULL)
         {
             globalMidiController = g_Supervisor.midiOutput;
-
             globalMidiController->StopPlayback();
             globalMidiController->ParseFile(midiFileIdx);
             globalMidiController->Play();
         }
+
         return FALSE;
     }
 
@@ -1173,6 +1172,7 @@ ZunResult Supervisor::SetupMidiPlayback(char *path)
     {
         return ZUN_ERROR;
     }
+
 success:
     return ZUN_SUCCESS;
 }

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1043,6 +1043,28 @@ void Controller::ResetKeyboard(void)
 }
 
 #pragma optimize("s", on)
+i32 Supervisor::PlayMidiFile(i32 midiFileIdx)
+{
+    MidiOutput *globalMidiController;
+
+    if (g_Supervisor.cfg.musicMode == MIDI)
+    {
+        if (g_Supervisor.midiOutput != NULL)
+        {
+            globalMidiController = g_Supervisor.midiOutput;
+
+            globalMidiController->StopPlayback();
+            globalMidiController->ParseFile(midiFileIdx);
+            globalMidiController->Play();
+        }
+        return FALSE;
+    }
+
+    return TRUE;
+}
+#pragma optimize("", on)
+
+#pragma optimize("s", on)
 ZunResult Supervisor::PlayAudio(char *path)
 {
     char wavName[256];

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1157,6 +1157,28 @@ ZunResult Supervisor::StopAudio()
 #pragma optimize("", on)
 
 #pragma optimize("s", on)
+ZunResult Supervisor::SetupMidiPlayback(char *path)
+{
+    // There doesn't seem to be a way to recreate the jump assembly needed without gotos?
+    // Standard short circuiting boolean operators and nested conditionals don't seem to work, at least
+    if (g_Supervisor.cfg.musicMode == MIDI)
+    {
+        goto success;
+    }
+    else if (g_Supervisor.cfg.musicMode == WAV) 
+    {
+        goto success;
+    }
+    else
+    {
+        return ZUN_ERROR;
+    }
+success:
+    return ZUN_SUCCESS;
+}
+#pragma optimize("", on)
+
+#pragma optimize("s", on)
 ZunResult Supervisor::FadeOutMusic(f32 fadeOutSeconds)
 {
     i32 unused1;

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1112,6 +1112,32 @@ ZunResult Supervisor::PlayAudio(char *path)
 #pragma optimize("", on)
 
 #pragma optimize("s", on)
+ZunResult Supervisor::StopAudio()
+{
+    if (g_Supervisor.cfg.musicMode == MIDI)
+    {
+        if (g_Supervisor.midiOutput != NULL)
+        {
+            g_Supervisor.midiOutput->StopPlayback();
+        }
+    }
+    else
+    {
+        if (g_Supervisor.cfg.musicMode == WAV)
+        {
+            g_SoundPlayer.StopBGM();
+        }
+        else
+        {
+            return ZUN_ERROR;
+        }
+    }
+
+    return ZUN_SUCCESS;
+}
+#pragma optimize("", on)
+
+#pragma optimize("s", on)
 ZunResult Supervisor::FadeOutMusic(f32 fadeOutSeconds)
 {
     i32 unused1;

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1165,7 +1165,7 @@ ZunResult Supervisor::SetupMidiPlayback(char *path)
     {
         goto success;
     }
-    else if (g_Supervisor.cfg.musicMode == WAV) 
+    else if (g_Supervisor.cfg.musicMode == WAV)
     {
         goto success;
     }
@@ -1204,7 +1204,7 @@ ZunResult Supervisor::FadeOutMusic(f32 fadeOutSeconds)
             {
                 if (this->effectiveFramerateMultiplier > 1.0f)
                 {
-                    g_SoundPlayer.FadeOut(fadeOutSeconds);                    
+                    g_SoundPlayer.FadeOut(fadeOutSeconds);
                 }
                 else
                 {

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -1043,6 +1043,25 @@ void Controller::ResetKeyboard(void)
 }
 
 #pragma optimize("s", on)
+ZunBool Supervisor::ReadMidiFile(u32 midiFileIdx, char *path)
+{
+    // Return conventions seem opposite of normal? But they're never used anyway
+    if (g_Supervisor.cfg.musicMode == MIDI)
+    {
+        if (g_Supervisor.midiOutput != NULL)
+        {
+            g_Supervisor.midiOutput->ReadFileData(midiFileIdx, path);
+        }
+        return FALSE;
+    }
+    else
+    {
+        return TRUE;
+    }
+}
+#pragma optimize("", on)
+
+#pragma optimize("s", on)
 i32 Supervisor::PlayMidiFile(i32 midiFileIdx)
 {
     MidiOutput *globalMidiController;


### PR DESCRIPTION
This implements any remaining sound functions outside of the two midi classes, which allows stage music to correctly play, as well as transition to the boss music and fade out when needed. It also changes `SoundPlayer::LoadSound` in a few places to achieve a 100% match. All newly implemented functions are 100% matches.
Implements:

- `Supervisor::ReadMidiFile`
- `Supervisor::PlayMidiFile`
- `Supervisor::StopAudio`
- `Supervisor::SetupMidiPlayback`
- `Supervisor::FadeOutMusic`