### PR TITLE
Fully implement MidiTimer and MidiDevice

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -198,6 +198,7 @@ th06::MainMenu::ColorMenuItem
 th06::MainMenu::LoadReplayMenu
 th06::MidiDevice::MidiDevice
 th06::MidiDevice::Close
+th06::MidiDevice::OpenDevice
 th06::MidiDevice::~MidiDevice
 th06::MidiOutput::MidiOutput
 th06::MidiOutput::~MidiOutput

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -203,6 +203,7 @@ th06::MidiOutput::~MidiOutput
 th06::MidiTimer::MidiTimer
 th06::MidiTimer::~MidiTimer
 th06::MidiTimer::StopTimer
+th06::MidiTimer::DefaultTimerCallback
 th06::Stage::RegisterChain
 th06::Stage::CutChain
 th06::Stage::AddedCallback

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -202,6 +202,7 @@ th06::MidiOutput::MidiOutput
 th06::MidiOutput::~MidiOutput
 th06::MidiTimer::MidiTimer
 th06::MidiTimer::~MidiTimer
+th06::MidiTimer::StopTimer
 th06::Stage::RegisterChain
 th06::Stage::CutChain
 th06::Stage::AddedCallback

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -200,6 +200,7 @@ th06::MidiDevice::MidiDevice
 th06::MidiDevice::Close
 th06::MidiDevice::OpenDevice
 th06::MidiDevice::SendShortMsg
+th06::MidiDevice::SendLongMsg
 th06::MidiDevice::~MidiDevice
 th06::MidiOutput::MidiOutput
 th06::MidiOutput::~MidiOutput

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -199,6 +199,7 @@ th06::MainMenu::LoadReplayMenu
 th06::MidiDevice::MidiDevice
 th06::MidiDevice::Close
 th06::MidiDevice::OpenDevice
+th06::MidiDevice::SendShortMsg
 th06::MidiDevice::~MidiDevice
 th06::MidiOutput::MidiOutput
 th06::MidiOutput::~MidiOutput

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -197,6 +197,7 @@ th06::MainMenu::OnUpdateOptionsMenu
 th06::MainMenu::ColorMenuItem
 th06::MainMenu::LoadReplayMenu
 th06::MidiDevice::MidiDevice
+th06::MidiDevice::Close
 th06::MidiDevice::~MidiDevice
 th06::MidiOutput::MidiOutput
 th06::MidiOutput::~MidiOutput

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -2,7 +2,6 @@ th06::EclManager::Unload
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing
 th06::MidiDevice::Close
-th06::MidiTimer::DefaultTimerCallback
 th06::MidiOutput::ClearTracks
 th06::MidiOutput::OnTimerElapsed
 th06::MidiOutput::StopPlayback

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -1,7 +1,6 @@
 th06::EclManager::Unload
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing
-th06::MidiDevice::Close
 th06::MidiOutput::ClearTracks
 th06::MidiOutput::OnTimerElapsed
 th06::MidiOutput::StopPlayback

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -2,6 +2,7 @@ th06::EclManager::Unload
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing
 th06::MidiDevice::Close
+th06::MidiTimer::DefaultTimerCallback
 th06::MidiOutput::ClearTracks
 th06::MidiOutput::OnTimerElapsed
 th06::MidiOutput::StopPlayback

--- a/config/stubbed.csv
+++ b/config/stubbed.csv
@@ -2,7 +2,6 @@ th06::EclManager::Unload
 th06::AsciiManager::DrawPopupsWithHwVertexProcessing
 th06::AsciiManager::DrawPopupsWithoutHwVertexProcessing
 th06::MidiDevice::Close
-th06::MidiTimer::StopTimer
 th06::MidiOutput::ClearTracks
 th06::MidiOutput::OnTimerElapsed
 th06::MidiOutput::StopPlayback

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -30,6 +30,24 @@ i32 MidiTimer::StopTimer()
     return 1;
 }
 
+u32 MidiTimer::StartTimer(u32 delay, LPTIMECALLBACK cb, DWORD_PTR data)
+{
+    this->StopTimer();
+    timeBeginPeriod(this->timeCaps.wPeriodMin);
+
+    if (cb != NULL)
+    {
+        this->timerId = timeSetEvent(delay, this->timeCaps.wPeriodMin, cb, data, TIME_PERIODIC);
+    }
+    else
+    {
+        this->timerId = timeSetEvent(delay, this->timeCaps.wPeriodMin, (LPTIMECALLBACK)MidiTimer::DefaultTimerCallback,
+                                     (DWORD_PTR)this, TIME_PERIODIC);
+    }
+
+    return this->timerId;
+}
+
 MidiTimer::~MidiTimer()
 {
     this->StopTimer();

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -4,6 +4,7 @@
 #include <mmsystem.h>
 
 #include "MidiOutput.hpp"
+#include "Supervisor.hpp"
 
 namespace th06
 {
@@ -79,6 +80,26 @@ ZunResult MidiDevice::Close()
     this->handle = 0;
 
     return ZUN_SUCCESS;
+}
+
+ZunBool MidiDevice::OpenDevice(u32 uDeviceId)
+{
+    if (this->handle != 0)
+    {
+        if (this->deviceId != uDeviceId)
+        {
+            this->Close();
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    this->deviceId = uDeviceId;
+
+    return midiOutOpen(&this->handle, uDeviceId, (DWORD_PTR)g_Supervisor.hwndGameWindow, NULL, CALLBACK_WINDOW) !=
+           MMSYSERR_NOERROR;
 }
 
 MidiDevice::~MidiDevice()

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -130,6 +130,23 @@ ZunBool MidiDevice::SendShortMsg(u8 midiStatus, u8 firstByte, u8 secondByte)
     }
 }
 
+ZunBool MidiDevice::SendLongMsg(LPMIDIHDR pmh)
+{
+    if (this->handle == 0)
+    {
+        return false;
+    }
+    else
+    {
+        if (midiOutPrepareHeader(this->handle, pmh, sizeof(*pmh)) != MMSYSERR_NOERROR)
+        {
+            return true;
+        }
+
+        return midiOutLongMsg(this->handle, pmh, sizeof(*pmh)) != MMSYSERR_NOERROR;
+    }
+}
+
 MidiDevice::~MidiDevice()
 {
     this->Close();

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -7,6 +7,7 @@ MidiTimer::MidiTimer()
     timeGetDevCaps(&this->timeCaps, sizeof(TIMECAPS));
     this->timerId = 0;
 }
+
 void MidiTimer::OnTimerElapsed()
 {
 }
@@ -21,6 +22,7 @@ MidiDevice::MidiDevice()
     this->handle = NULL;
     this->deviceId = 0;
 }
+
 MidiDevice::~MidiDevice()
 {
     this->Close();
@@ -61,4 +63,5 @@ MidiOutput::~MidiOutput()
         this->ReleaseFileData(i);
     }
 }
+
 }; // namespace th06

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -67,6 +67,20 @@ MidiDevice::MidiDevice()
     this->deviceId = 0;
 }
 
+ZunResult MidiDevice::Close()
+{
+    if (this->handle == 0)
+    {
+        return ZUN_ERROR;
+    }
+
+    midiOutReset(this->handle);
+    midiOutClose(this->handle);
+    this->handle = 0;
+
+    return ZUN_SUCCESS;
+}
+
 MidiDevice::~MidiDevice()
 {
     this->Close();

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -48,6 +48,13 @@ u32 MidiTimer::StartTimer(u32 delay, LPTIMECALLBACK cb, DWORD_PTR data)
     return this->timerId;
 }
 
+void MidiTimer::DefaultTimerCallback(u32 uTimerID, u32 uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2)
+{
+    MidiTimer *timer = (MidiTimer *)dwUser;
+
+    timer->OnTimerElapsed();
+}
+
 MidiTimer::~MidiTimer()
 {
     this->StopTimer();

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -102,6 +102,34 @@ ZunBool MidiDevice::OpenDevice(u32 uDeviceId)
            MMSYSERR_NOERROR;
 }
 
+union MidiShortMsg {
+    struct
+    {
+        u8 midiStatus;
+        i8 firstByte;
+        i8 secondByte;
+        i8 unused;
+    } msg;
+    u32 dwMsg;
+};
+
+ZunBool MidiDevice::SendShortMsg(u8 midiStatus, u8 firstByte, u8 secondByte)
+{
+    MidiShortMsg pkt;
+
+    if (this->handle == 0)
+    {
+        return false;
+    }
+    else
+    {
+        pkt.msg.midiStatus = midiStatus;
+        pkt.msg.firstByte = firstByte;
+        pkt.msg.secondByte = secondByte;
+        return midiOutShortMsg(this->handle, pkt.dwMsg) != MMSYSERR_NOERROR;
+    }
+}
+
 MidiDevice::~MidiDevice()
 {
     this->Close();

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -1,3 +1,8 @@
+#include "inttypes.hpp"
+#include <Windows.h>
+#include <mmreg.h>
+#include <mmsystem.h>
+
 #include "MidiOutput.hpp"
 
 namespace th06
@@ -11,6 +16,20 @@ MidiTimer::MidiTimer()
 void MidiTimer::OnTimerElapsed()
 {
 }
+
+i32 MidiTimer::StopTimer()
+{
+    if (this->timerId != 0)
+    {
+        timeKillEvent(this->timerId);
+    }
+
+    timeEndPeriod(this->timeCaps.wPeriodMin);
+    this->timerId = 0;
+
+    return 1;
+}
+
 MidiTimer::~MidiTimer()
 {
     this->StopTimer();

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ZunBool.hpp"
 #include "ZunResult.hpp"
 #include "inttypes.hpp"
 #include <Windows.h>
@@ -42,6 +43,7 @@ struct MidiDevice
     ~MidiDevice();
 
     ZunResult Close();
+    ZunBool OpenDevice(u32 uDeviceId);
 
     HMIDIOUT handle;
     u32 deviceId;

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -44,6 +44,7 @@ struct MidiDevice
 
     ZunResult Close();
     ZunBool OpenDevice(u32 uDeviceId);
+    ZunBool SendShortMsg(u8 midiStatus, u8 firstByte, u8 secondByte);
 
     HMIDIOUT handle;
     u32 deviceId;

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -14,6 +14,9 @@ struct MidiTimer
     virtual void OnTimerElapsed();
 
     i32 StopTimer();
+    u32 StartTimer(u32 delay, LPTIMECALLBACK cb, DWORD_PTR data);
+
+    static void DefaultTimerCallback(u32 uTimerID, u32 uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2);
 
     u32 timerId;
     TIMECAPS timeCaps;

--- a/src/MidiOutput.hpp
+++ b/src/MidiOutput.hpp
@@ -45,6 +45,7 @@ struct MidiDevice
     ZunResult Close();
     ZunBool OpenDevice(u32 uDeviceId);
     ZunBool SendShortMsg(u8 midiStatus, u8 firstByte, u8 secondByte);
+    ZunBool SendLongMsg(LPMIDIHDR pmh);
 
     HMIDIOUT handle;
     u32 deviceId;


### PR DESCRIPTION
Should 100% match.

3f9ba92b8387e03e1b572a347e79840d78ab9c9b needs to be dropped once the auto mapping update is merged.