### PR TITLE
Edit frameskipConfig comment

### DIFF
--- a/src/Supervisor.hpp
+++ b/src/Supervisor.hpp
@@ -62,7 +62,7 @@ struct GameConfiguration
     u8 playSounds;
     u8 defaultDifficulty;
     u8 windowed;
-    // 0 = fullspeed, 1 = 1/2 speed, 2 = 1/4 speed.
+    // 0 = fullspeed, 1 = 1/2 speed, 2 = 1/3 speed.
     u8 frameskipConfig;
     i16 padXAxis;
     i16 padYAxis;


### PR DESCRIPTION
Here is a custom.exe screenshot that has 1/2 1/3 in it:

![custom exe screenshot](https://github.com/user-attachments/assets/41ed21e8-5f47-4ae3-8857-9f1135850e23)

And here is a quote from custom.txt, original and translation (mine).

```
　・描画間隔
　　毎回、１／２回、１／３回から選択出来ます。
　　毎回　　　・・・　通常はこれを選んでください。
　　１／２回　・・・　描画のみ２フレームに１回しか行いません。
　　　　　　　　　　　見た目はがくがくして見辛くなりますが、処理が軽減されます
　　１／３回　・・・　描画のみ３フレームに１回しか行いません。
　　　　　　　　　　　見た目はがくがくして激しく見辛くなりますが、激しく処理が
　　　　　　　　　　　軽減されます
```

```
* Drawing interval.
Possible values are: every time, every second, every third.
Every time   -- normally choose this.
Every second -- draw only every second frame.
                Game starts running with skips, gets harder to look at,
                but saves processing power.
Every third  -- draw only every third frame.
                Game starts skipping even more,
                but saves processing power even more.
```