### PR TITLE
Improve Pbg3Archive accuracy

### DIFF
--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -76,12 +76,6 @@ i32 Pbg3Archive::Release()
 
 i32 Pbg3Archive::FindEntry(char *path)
 {
-    // Why was this here? It's certainly not present in the assembly.
-    // if (this->numOfEntries == 0)
-    //{
-    //    return -1;
-    //}
-
     for (u32 entryIdx = 0; entryIdx < this->numOfEntries; entryIdx += 1)
     {
         char *entryFilename = this->entries[entryIdx].filename;

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -76,15 +76,16 @@ i32 Pbg3Archive::Release()
 
 i32 Pbg3Archive::FindEntry(char *path)
 {
-    if (this->numOfEntries == 0)
-    {
-        return -1;
-    }
+    // Why was this here? It's certainly not present in the assembly.
+    //if (this->numOfEntries == 0)
+    //{
+    //    return -1;
+    //}
 
     for (u32 entryIdx = 0; entryIdx < this->numOfEntries; entryIdx += 1)
     {
         char *entryFilename = this->entries[entryIdx].filename;
-        i32 res = strcmp(entryFilename, path);
+        i32 res = strcmp(path, entryFilename);
         if (res == 0)
         {
             return entryIdx;

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -154,8 +154,13 @@ Pbg3Archive::~Pbg3Archive()
 
 i32 Pbg3Archive::Load(char *path)
 {
+    if (this->Release() == NULL)
+    {
+        return FALSE;
+    }
+
     this->parser = new Pbg3Parser();
-    if (this->parser == NULL)
+    if ( this->parser == NULL )
     {
         return FALSE;
     }
@@ -163,6 +168,12 @@ i32 Pbg3Archive::Load(char *path)
     if (this->parser->OpenArchive(path) == FALSE)
     {
         delete this->parser;
+        // TODO: There should be an instruction here:
+        //     mov dword ptr [esi], 0x0
+        // This corresponds directly to this C++ code:
+        //     this->parser = NULL;
+        // But inserting this line of code causes a branch in the ASM wrapper code for the scalar deleting destructor
+        // call to point to the wrong place!
         return FALSE;
     }
 

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -77,7 +77,7 @@ i32 Pbg3Archive::Release()
 i32 Pbg3Archive::FindEntry(char *path)
 {
     // Why was this here? It's certainly not present in the assembly.
-    //if (this->numOfEntries == 0)
+    // if (this->numOfEntries == 0)
     //{
     //    return -1;
     //}
@@ -161,7 +161,7 @@ i32 Pbg3Archive::Load(char *path)
     }
 
     this->parser = new Pbg3Parser();
-    if ( this->parser == NULL )
+    if (this->parser == NULL)
     {
         return FALSE;
     }

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -96,7 +96,7 @@ i32 Pbg3Archive::FindEntry(char *path)
 
 u32 Pbg3Archive::GetEntrySize(u32 entryIdx)
 {
-    if (this->numOfEntries <= entryIdx)
+    if (entryIdx >= this->numOfEntries)
     {
         return 0;
     }


### PR DESCRIPTION
`Pbg3Archive::Load` 88% -> 98%
`Pbg3Archive::FindEntry` 82% -> 100%
`Pbg3Archive::GetEntrySize` 84% -> 100%

There is currently an issue with the codegen for `Pbg3Parser`'s scalar deleting destructor that is preventing `Pbg3Archive::Load` and `Pbg3Archive::ParseHeader` from matching.