### PR TITLE
Archive code matches and accuracy improvements

### DIFF
--- a/src/pbg3/FileAbstraction.cpp
+++ b/src/pbg3/FileAbstraction.cpp
@@ -150,6 +150,7 @@ u8 *FileAbstraction::ReadWholeFile(u32 maxSize)
     }
 
     u32 dataLen = this->GetSize();
+    u32 outDataLen;
     if (dataLen <= maxSize)
     {
         u8 *data = reinterpret_cast<u8 *>(LocalAlloc(LPTR, dataLen));
@@ -160,13 +161,13 @@ u8 *FileAbstraction::ReadWholeFile(u32 maxSize)
             // is buggy.
             if (this->Seek(oldLocation, FILE_BEGIN) != 0)
             {
-                u32 outDataLen;
-                if (this->Read(data, dataLen, &outDataLen) != 0)
+                if (this->Read(data, dataLen, &outDataLen) == 0)
                 {
-                    this->Seek(oldLocation, FILE_BEGIN);
-                    return data;
+                    LocalFree(data);
+                    return NULL;
                 }
-                LocalFree(data);
+                this->Seek(oldLocation, FILE_BEGIN);
+                return data;
             }
             // Yes, this case leaks the data. Amazing, I know.
         }

--- a/src/pbg3/FileAbstraction.cpp
+++ b/src/pbg3/FileAbstraction.cpp
@@ -106,16 +106,24 @@ i32 FileAbstraction::ReadByte()
     }
 }
 
-i32 FileAbstraction::WriteByte(u8 b)
+i32 FileAbstraction::WriteByte(u32 b)
 {
-    u8 res;
+    u8 outByte;
     u32 outBytesWritten;
-
-    if (this->Write(&b, 1, &outBytesWritten) == FALSE)
+    
+    outByte = b;
+    if (this->Write(&outByte, 1, &outBytesWritten) == FALSE)
     {
         return -1;
     }
-    return outBytesWritten != 0 ? b : -1;
+    else
+    {
+        if (outBytesWritten == 0)
+        {
+            return -1;
+        }
+        return b;
+    }
 }
 
 i32 FileAbstraction::Seek(u32 amount, u32 seekFrom)

--- a/src/pbg3/FileAbstraction.cpp
+++ b/src/pbg3/FileAbstraction.cpp
@@ -96,7 +96,14 @@ i32 FileAbstraction::ReadByte()
     {
         return -1;
     }
-    return outBytesRead != 0 ? data : -1;
+    else
+    {
+        if (outBytesRead == 0)
+        {
+            return -1;
+        }
+        return data;
+    }
 }
 
 i32 FileAbstraction::WriteByte(u8 b)

--- a/src/pbg3/FileAbstraction.cpp
+++ b/src/pbg3/FileAbstraction.cpp
@@ -110,7 +110,7 @@ i32 FileAbstraction::WriteByte(u32 b)
 {
     u8 outByte;
     u32 outBytesWritten;
-    
+
     outByte = b;
     if (this->Write(&outByte, 1, &outBytesWritten) == FALSE)
     {

--- a/src/pbg3/FileAbstraction.hpp
+++ b/src/pbg3/FileAbstraction.hpp
@@ -51,8 +51,10 @@ class FileAbstraction : public IFileAbstraction
         return GetFileTime(this->handle, NULL, NULL, lastWriteTime);
     }
 
-  private:
+  protected:
     HANDLE handle;
+  
+  private:
     DWORD access;
 };
 C_ASSERT(sizeof(FileAbstraction) == 0xc);

--- a/src/pbg3/FileAbstraction.hpp
+++ b/src/pbg3/FileAbstraction.hpp
@@ -14,7 +14,7 @@ class IFileAbstraction
     virtual i32 Read(u8 *data, u32 dataLen, u32 *numBytesRead) = 0;
     virtual i32 Write(u8 *data, u32 dataLen, u32 *outWritten) = 0;
     virtual i32 ReadByte() = 0;
-    virtual i32 WriteByte(u8 b) = 0;
+    virtual i32 WriteByte(u32 b) = 0;
     virtual i32 Seek(u32 amount, u32 seekFrom) = 0;
     virtual u32 Tell() = 0;
     virtual u32 GetSize() = 0;
@@ -32,7 +32,7 @@ class FileAbstraction : public IFileAbstraction
     virtual i32 Read(u8 *data, u32 dataLen, u32 *numBytesRead);
     virtual i32 Write(u8 *data, u32 dataLen, u32 *outWritten);
     virtual i32 ReadByte();
-    virtual i32 WriteByte(u8 b);
+    virtual i32 WriteByte(u32 b);
     virtual i32 Seek(u32 amount, u32 seekFrom);
     virtual u32 Tell();
     virtual u32 GetSize();

--- a/src/pbg3/FileAbstraction.hpp
+++ b/src/pbg3/FileAbstraction.hpp
@@ -53,7 +53,7 @@ class FileAbstraction : public IFileAbstraction
 
   protected:
     HANDLE handle;
-  
+
   private:
     DWORD access;
 };

--- a/src/pbg3/IPbg3Parser.hpp
+++ b/src/pbg3/IPbg3Parser.hpp
@@ -18,7 +18,7 @@ class IPbg3Parser
     u32 ReadString(char *out, u32 maxSize);
     virtual i32 ReadBit() = 0;
     virtual u32 ReadInt(u32 numBitsAsPowersOf2) = 0;
-    virtual u8 ReadByteAssumeAligned() = 0;
+    virtual i32 ReadByteAssumeAligned() = 0;
     virtual i32 SeekToOffset(u32 fileOffset) = 0;
     virtual i32 SeekToNextByte() = 0;
     virtual i32 ReadByteAlignedData(u8 *data, u32 bytesToRead) = 0;

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -97,15 +97,10 @@ i32 Pbg3Archive::Release()
 
 i32 Pbg3Archive::FindEntry(char *path)
 {
-    if (this->numOfEntries == 0)
-    {
-        return -1;
-    }
-
     for (u32 entryIdx = 0; entryIdx < this->numOfEntries; entryIdx += 1)
     {
         char *entryFilename = this->entries[entryIdx].filename;
-        i32 res = strcmp(entryFilename, path);
+        i32 res = strcmp(path, entryFilename);
         if (res == 0)
         {
             return entryIdx;

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -19,7 +19,11 @@ i32 Pbg3Archive::ParseHeader()
 {
     if (this->parser->ReadMagic() != 0x33474250)
     {
-        delete this->parser;
+        if (this->parser != NULL)
+        {
+            delete this->parser;
+            this->parser = NULL;
+        }
         return FALSE;
     }
 
@@ -27,14 +31,22 @@ i32 Pbg3Archive::ParseHeader()
     this->fileTableOffset = this->parser->ReadVarInt();
     if (this->parser->SeekToOffset(this->fileTableOffset) == FALSE)
     {
-        delete this->parser;
+        if (this->parser != NULL)
+        {
+            delete this->parser;
+            this->parser = NULL;
+        }
         return FALSE;
     }
 
     this->entries = new Pbg3Entry[this->numOfEntries];
     if (this->entries == NULL)
     {
-        delete this->parser;
+        if (this->parser != NULL)
+        {
+            delete this->parser;
+            this->parser = NULL;
+        }
         return FALSE;
     }
 
@@ -47,8 +59,17 @@ i32 Pbg3Archive::ParseHeader()
         this->entries[idx].uncompressedSize = this->parser->ReadVarInt();
         if (this->parser->ReadString(this->entries[idx].filename, sizeof(this->entries[idx].filename)) == FALSE)
         {
-            delete this->parser;
-            delete[] this->entries;
+            if (this->parser != NULL)
+            {
+                delete this->parser;
+                this->parser = NULL;
+            }
+            if (this->entries != NULL)
+            {
+                delete[] this->entries;
+                this->entries = NULL;
+            }
+
             return FALSE;
         }
     }

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -197,71 +197,51 @@ i32 Pbg3Archive::Load(char *path)
 #define LZSS_DICTSIZE_MASK 0x1fff
 #define LZSS_MIN_MATCH 3
 
-class BitStream
-{
-  public:
-    BitStream(u8 *data, u32 size) : data(data), size(size), curByte(0), curByteIdx(0), curBitIdx(0x80), m_checksum(0)
-    {
-    }
-    u32 Read(u32 numBits)
-    {
-        u32 ret = 0;
-        while (numBits != 0)
-        {
-            if (this->curBitIdx == 0x80)
-            {
-                this->curByte = *this->data;
-                if (this->curByteIdx < this->size)
-                {
-                    this->data += 1;
-                    this->curByteIdx += 1;
-                }
-                else
-                {
-                    this->curByte = 0;
-                }
-                this->m_checksum += this->curByte;
-            }
-            if ((this->curByte & this->curBitIdx) != 0)
-            {
-                ret |= (1 << (numBits - 1));
-            }
-            numBits--;
-            this->curBitIdx >>= 1;
-            if (this->curBitIdx == 0)
-            {
-                this->curBitIdx = 0x80;
-            }
-        }
-        return ret;
-    }
+#define BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum) \
+    byte = *dataCursor; \
+    if ((i32) (currDataPtr - baseDataPtr) >= (i32) size) \
+    { \
+        currByte = 0; \
+    } \
+    else \
+    { \
+        dataCursor++; \
+    } \
+    checksum += byte;
 
-    u32 checksum()
-    {
-        return this->m_checksum;
-    }
-
-  private:
-    u8 *data;
-    u8 curByte;
-    u32 curByteIdx;
-    u32 curBitIdx;
-    u32 size;
-    u32 m_checksum;
-};
+#define BITFIELD_READ_BITS(bitsCount, outBitMask, bitfieldReturn, inBitMask, byte, currDataPtr, baseDataPtr, size, checksum) \
+    outBitMask = 0x01 << (bitsCount - 1); \
+    bitfieldReturn = 0; \
+    while (outBitMask != 0) \
+    { \
+        if (inBitMask == 0x80) \
+        { \
+            BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum) \
+        } \
+        if ((byte & inBitMask) != 0) \
+        { \
+            bitfieldReturn |= outBitMask; \
+        } \
+     \
+        outBitMask >>= 1; \
+        inBitMask >>= 1; \
+        if (inBitMask == 0) \
+        { \
+            inBitMask = 0x80; \
+        } \
+    } \
 
 u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
 {
-    if (entryIdx >= this->numOfEntries)
+    if (entryIdx >= this->numOfEntries || this->parser == NULL)
         return NULL;
 
-    if (this->parser == NULL)
-        return NULL;
-
-    u32 size = this->entries[entryIdx].uncompressedSize;
+    u32 size = this->GetEntrySize(entryIdx);
     u8 *out = (u8 *)malloc(size);
     if (out == NULL)
         return NULL;
+
+    u8 *outCursor = out;
 
     u32 expectedCsum;
     u8 *rawData = this->ReadEntryRaw(&size, &expectedCsum, entryIdx);
@@ -272,49 +252,92 @@ u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
         return NULL;
     }
 
-    u8 dict[LZSS_DICTSIZE];
-    memset(dict, 0, sizeof(dict));
+    u8 *dataCursor = rawData;
+    u8 inBitMask = 0x80;
+    u32 checksum = 0;
     u32 dictHead = 1;
 
-    u32 bytesWritten = 0;
+    
+    u8 dict[LZSS_DICTSIZE];
 
-    BitStream bs = BitStream(rawData, size);
+    // Memset doesn't produce matching assembly
+    for (i32 i = 0; i < LZSS_DICTSIZE; i++)
+    {
+        dict[i] = 0;
+    }
+
+    u32 currByte;
+    u32 bitfieldReturn;
+    u32 outBitMask;
+    u32 matchOffset;
+
     while (TRUE)
     {
-        if (bs.Read(1) != 0)
+        if (inBitMask == 0x80)
         {
-            u8 c = bs.Read(8);
-            out[bytesWritten] = c;
-            bytesWritten += 1;
-            dict[dictHead] = c;
+            BITFIELD_NEW_BYTE(currByte, dataCursor, rawData, size, checksum)
+        }
+
+        u32 opcode = currByte & inBitMask;
+        inBitMask >>= 1;
+        if (inBitMask == 0x00)
+        {
+            inBitMask = 0x80;
+        }
+
+        // Read literal byte from next 8 bits
+        if (opcode != 0)
+        {
+            BITFIELD_READ_BITS(8, outBitMask, bitfieldReturn, inBitMask, currByte, dataCursor, rawData, size, checksum)
+            *outCursor = bitfieldReturn;
+            outCursor++;
+            dict[dictHead] = bitfieldReturn;
             dictHead = (dictHead + 1) & LZSS_DICTSIZE_MASK;
         }
+        // Copy from dictionary, 13 bit offset, then 4 bit length
         else
         {
-            u32 matchOffset = bs.Read(13);
-            if (!matchOffset)
+            BITFIELD_READ_BITS(13, outBitMask, bitfieldReturn, inBitMask, currByte, dataCursor, rawData, size, checksum)
+            matchOffset = bitfieldReturn;
+
+            if (matchOffset == 0)
                 break;
 
-            u32 matchLen = bs.Read(4) + LZSS_MIN_MATCH;
+            BITFIELD_READ_BITS(4, outBitMask, bitfieldReturn, inBitMask, currByte, dataCursor, rawData, size, checksum)
 
-            for (u32 i = 0; i < matchLen; ++i)
+            for (i32 i = 0; i <= (i32) bitfieldReturn + 2; i++)
             {
-                u8 c = dict[(matchOffset + i) & LZSS_DICTSIZE_MASK];
-                out[bytesWritten] = c;
-                bytesWritten += 1;
+                u32 c = dict[(matchOffset + i) & LZSS_DICTSIZE_MASK];
+                *outCursor = c;
+                outCursor++;
                 dict[dictHead] = c;
                 dictHead = (dictHead + 1) & LZSS_DICTSIZE_MASK;
             }
         }
     }
-
-    if (this->entries[entryIdx].checksum != bs.checksum())
+    // ???? No clue what this was supposed to be
+    while (inBitMask != 0x80)
     {
-        free(out);
-        out = NULL;
+        if (inBitMask == 0x80 && (i32) (dataCursor - rawData) < (i32) size)
+        {
+            dataCursor++;
+        }
+
+        inBitMask >>= 1;
+        if (inBitMask == 0)
+        {
+            inBitMask = 0x80;
+        }
     }
 
     free(rawData);
+
+    if (expectedCsum != checksum)
+    {
+        free(out);
+        return NULL;
+    }
+
     return out;
 }
 }; // namespace th06

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -182,7 +182,8 @@ i32 Pbg3Archive::Load(char *path)
     }
 
     if (this->parser->OpenArchive(path) == FALSE)
-    {   if (this->parser != NULL)
+    {
+        if (this->parser != NULL)
         {
             delete this->parser;
             this->parser = NULL;
@@ -197,39 +198,40 @@ i32 Pbg3Archive::Load(char *path)
 #define LZSS_DICTSIZE_MASK 0x1fff
 #define LZSS_MIN_MATCH 3
 
-#define BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum) \
-    byte = *dataCursor; \
-    if ((i32) (currDataPtr - baseDataPtr) >= (i32) size) \
-    { \
-        currByte = 0; \
-    } \
-    else \
-    { \
-        dataCursor++; \
-    } \
+#define BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum)                                              \
+    byte = *dataCursor;                                                                                                \
+    if ((i32)(currDataPtr - baseDataPtr) >= (i32)size)                                                                 \
+    {                                                                                                                  \
+        currByte = 0;                                                                                                  \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        dataCursor++;                                                                                                  \
+    }                                                                                                                  \
     checksum += byte;
 
-#define BITFIELD_READ_BITS(bitsCount, outBitMask, bitfieldReturn, inBitMask, byte, currDataPtr, baseDataPtr, size, checksum) \
-    outBitMask = 0x01 << (bitsCount - 1); \
-    bitfieldReturn = 0; \
-    while (outBitMask != 0) \
-    { \
-        if (inBitMask == 0x80) \
-        { \
-            BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum) \
-        } \
-        if ((byte & inBitMask) != 0) \
-        { \
-            bitfieldReturn |= outBitMask; \
-        } \
-     \
-        outBitMask >>= 1; \
-        inBitMask >>= 1; \
-        if (inBitMask == 0) \
-        { \
-            inBitMask = 0x80; \
-        } \
-    } \
+#define BITFIELD_READ_BITS(bitsCount, outBitMask, bitfieldReturn, inBitMask, byte, currDataPtr, baseDataPtr, size,     \
+                           checksum)                                                                                   \
+    outBitMask = 0x01 << (bitsCount - 1);                                                                              \
+    bitfieldReturn = 0;                                                                                                \
+    while (outBitMask != 0)                                                                                            \
+    {                                                                                                                  \
+        if (inBitMask == 0x80)                                                                                         \
+        {                                                                                                              \
+            BITFIELD_NEW_BYTE(byte, currDataPtr, baseDataPtr, size, checksum)                                          \
+        }                                                                                                              \
+        if ((byte & inBitMask) != 0)                                                                                   \
+        {                                                                                                              \
+            bitfieldReturn |= outBitMask;                                                                              \
+        }                                                                                                              \
+                                                                                                                       \
+        outBitMask >>= 1;                                                                                              \
+        inBitMask >>= 1;                                                                                               \
+        if (inBitMask == 0)                                                                                            \
+        {                                                                                                              \
+            inBitMask = 0x80;                                                                                          \
+        }                                                                                                              \
+    }
 
 u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
 {
@@ -257,7 +259,6 @@ u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
     u32 checksum = 0;
     u32 dictHead = 1;
 
-    
     u8 dict[LZSS_DICTSIZE];
 
     // Memset doesn't produce matching assembly
@@ -305,7 +306,7 @@ u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
 
             BITFIELD_READ_BITS(4, outBitMask, bitfieldReturn, inBitMask, currByte, dataCursor, rawData, size, checksum)
 
-            for (i32 i = 0; i <= (i32) bitfieldReturn + 2; i++)
+            for (i32 i = 0; i <= (i32)bitfieldReturn + 2; i++)
             {
                 u32 c = dict[(matchOffset + i) & LZSS_DICTSIZE_MASK];
                 *outCursor = c;
@@ -318,7 +319,7 @@ u8 *Pbg3Archive::ReadDecompressEntry(u32 entryIdx, char *filename)
     // ???? No clue what this was supposed to be
     while (inBitMask != 0x80)
     {
-        if (inBitMask == 0x80 && (i32) (dataCursor - rawData) < (i32) size)
+        if (inBitMask == 0x80 && (i32)(dataCursor - rawData) < (i32)size)
         {
             dataCursor++;
         }

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -111,7 +111,7 @@ i32 Pbg3Archive::FindEntry(char *path)
 
 u32 Pbg3Archive::GetEntrySize(u32 entryIdx)
 {
-    if (this->numOfEntries <= entryIdx)
+    if (entryIdx >= this->numOfEntries)
     {
         return 0;
     }

--- a/src/pbg3/Pbg3Archive.cpp
+++ b/src/pbg3/Pbg3Archive.cpp
@@ -92,7 +92,7 @@ i32 Pbg3Archive::Release()
         this->entries = NULL;
     }
     delete this->unk;
-    return 1;
+    return TRUE;
 }
 
 i32 Pbg3Archive::FindEntry(char *path)
@@ -170,6 +170,11 @@ Pbg3Archive::~Pbg3Archive()
 
 i32 Pbg3Archive::Load(char *path)
 {
+    if (this->Release() == FALSE)
+    {
+        return FALSE;
+    }
+
     this->parser = new Pbg3Parser();
     if (this->parser == NULL)
     {
@@ -177,8 +182,11 @@ i32 Pbg3Archive::Load(char *path)
     }
 
     if (this->parser->OpenArchive(path) == FALSE)
-    {
-        delete this->parser;
+    {   if (this->parser != NULL)
+        {
+            delete this->parser;
+            this->parser = NULL;
+        }
         return FALSE;
     }
 

--- a/src/pbg3/Pbg3Parser.cpp
+++ b/src/pbg3/Pbg3Parser.cpp
@@ -11,11 +11,11 @@ i32 Pbg3Parser::OpenArchive(char *path)
 {
     this->Close();
     this->Reset();
-    if (this->Open(path, "r") == FALSE)
+    if (this->FileAbstraction::Open(path, "r") == FALSE)
     {
         return FALSE;
     }
-    this->fileSize = this->GetSize();
+    this->fileSize = GetFileSize(this->handle, NULL);
     return TRUE;
 }
 

--- a/src/pbg3/Pbg3Parser.cpp
+++ b/src/pbg3/Pbg3Parser.cpp
@@ -11,7 +11,7 @@ i32 Pbg3Parser::OpenArchive(char *path)
 {
     this->Close();
     this->Reset();
-    if (this->FileAbstraction::Open(path, "r") == FALSE)
+    if (FileAbstraction::Open(path, "r") == FALSE)
     {
         return FALSE;
     }
@@ -34,7 +34,7 @@ i32 Pbg3Parser::ReadBit()
 
     if (this->bitIdxInCurByte == 0x80)
     {
-        this->curByte = this->FileAbstraction::ReadByte();
+        this->curByte = FileAbstraction::ReadByte();
         if (this->curByte == -1)
         {
             return FALSE;
@@ -66,7 +66,7 @@ u32 Pbg3Parser::ReadInt(u32 numBitsAsPowersOf2)
     {
         if (this->bitIdxInCurByte == 0x80)
         {
-            this->curByte = this->FileAbstraction::ReadByte();
+            this->curByte = FileAbstraction::ReadByte();
             if (this->curByte == -1)
             {
                 return FALSE;
@@ -112,7 +112,7 @@ i32 Pbg3Parser::SeekToOffset(u32 fileOffset)
         return FALSE;
     }
 
-    if (this->FileAbstraction::Seek(fileOffset, FILE_BEGIN) == FALSE)
+    if (FileAbstraction::Seek(fileOffset, FILE_BEGIN) == FALSE)
     {
         return FALSE;
     }
@@ -141,7 +141,7 @@ i32 Pbg3Parser::ReadByteAlignedData(u8 *data, u32 bytesToRead)
     u32 numBytesRead;
 
     this->SeekToNextByte();
-    return this->FileAbstraction::Read(data, bytesToRead, &numBytesRead);
+    return FileAbstraction::Read(data, bytesToRead, &numBytesRead);
 }
 
 i32 Pbg3Parser::GetLastWriteTime(LPFILETIME lastWriteTime)
@@ -154,7 +154,7 @@ i32 Pbg3Parser::GetLastWriteTime(LPFILETIME lastWriteTime)
     }
 
     // EWWWW abstraction violation much? (Maybe this is an inlined function?)
-    return this->GetLastWriteTime(lastWriteTime);
+    return FileAbstraction::GetLastWriteTime(lastWriteTime);
 }
 
 i32 Pbg3Parser::ReadByte()

--- a/src/pbg3/Pbg3Parser.cpp
+++ b/src/pbg3/Pbg3Parser.cpp
@@ -90,7 +90,7 @@ u32 Pbg3Parser::ReadInt(u32 numBitsAsPowersOf2)
     return result;
 }
 
-u8 Pbg3Parser::ReadByteAssumeAligned()
+i32 Pbg3Parser::ReadByteAssumeAligned()
 {
     if (this->offsetInFile < this->fileSize)
     {
@@ -157,10 +157,14 @@ i32 Pbg3Parser::GetLastWriteTime(LPFILETIME lastWriteTime)
     return FileAbstraction::GetLastWriteTime(lastWriteTime);
 }
 
+// Optimizing for size here needed to prevent the inlining of ReadByteAssumeAligned
+#pragma optimize("s", on)
 i32 Pbg3Parser::ReadByte()
 {
-    return this->ReadByteAssumeAligned();
+    // MSVC generates an add -0x18 instruction to get the caller base here, while the original binary uses a sub 0x18?
+    return Pbg3Parser::ReadByteAssumeAligned();
 }
+#pragma optimize("", on)
 
 Pbg3Parser::~Pbg3Parser()
 {

--- a/src/pbg3/Pbg3Parser.cpp
+++ b/src/pbg3/Pbg3Parser.cpp
@@ -34,7 +34,7 @@ i32 Pbg3Parser::ReadBit()
 
     if (this->bitIdxInCurByte == 0x80)
     {
-        this->curByte = this->ReadByte();
+        this->curByte = this->FileAbstraction::ReadByte();
         if (this->curByte == -1)
         {
             return FALSE;
@@ -66,7 +66,7 @@ u32 Pbg3Parser::ReadInt(u32 numBitsAsPowersOf2)
     {
         if (this->bitIdxInCurByte == 0x80)
         {
-            this->curByte = this->ReadByte();
+            this->curByte = this->FileAbstraction::ReadByte();
             if (this->curByte == -1)
             {
                 return FALSE;
@@ -112,7 +112,7 @@ i32 Pbg3Parser::SeekToOffset(u32 fileOffset)
         return FALSE;
     }
 
-    if (this->Seek(fileOffset, FILE_BEGIN) == FALSE)
+    if (this->FileAbstraction::Seek(fileOffset, FILE_BEGIN) == FALSE)
     {
         return FALSE;
     }
@@ -141,7 +141,7 @@ i32 Pbg3Parser::ReadByteAlignedData(u8 *data, u32 bytesToRead)
     u32 numBytesRead;
 
     this->SeekToNextByte();
-    return this->Read(data, bytesToRead, &numBytesRead);
+    return this->FileAbstraction::Read(data, bytesToRead, &numBytesRead);
 }
 
 i32 Pbg3Parser::GetLastWriteTime(LPFILETIME lastWriteTime)

--- a/src/pbg3/Pbg3Parser.hpp
+++ b/src/pbg3/Pbg3Parser.hpp
@@ -13,7 +13,7 @@ class Pbg3Parser : public IPbg3Parser, public FileAbstraction
     i32 OpenArchive(char *path);
     i32 ReadBit();
     u32 ReadInt(u32 numBitsAsPowersOf2);
-    u8 ReadByteAssumeAligned();
+    i32 ReadByteAssumeAligned();
     i32 SeekToOffset(u32 fileOffset);
     i32 SeekToNextByte();
     i32 ReadByteAlignedData(u8 *data, u32 bytesToRead);


### PR DESCRIPTION
Matches 

- Pbg3Archive::ParseHeader
- Pbg3Archive::FindEntry
- Pbg3Archive::GetEntrySize
- Pbg3Archive::Load
- Pbg3Parser::OpenArchive
- Pbg3Parser::ReadBit
- Pbg3Parser::ReadInt
- Pbg3Parser::SeekToOffset
- Pbg3Parser::ReadByteAlignedData
- Pbg3Parser::GetLastWriteTime
- FileAbstraction::ReadWholeFile
- FileAbstraction::ReadByte
- FileAbstraction::WriteByte

Most changes are relatively minor, including a lot of places where virtual functions have to be called directly for whatever reason.

Pbg3Parser::ReadByte is improved to a 50% match, with the difference being an instruction that is `sub 0x18` in the original code, but `add -0x18` in what MSVC generates with global optimizations.

Pbg3Archive::ReadDecompressEntry is improved to a 65% match by using the PCB's LZSS decompression code as a reference. 