### PR TITLE
Relocate AnmVm constructor

### DIFF
--- a/scripts/generate_detours.py
+++ b/scripts/generate_detours.py
@@ -42,6 +42,7 @@ def get_path_of_mangled_symbol(symbol):
 
 
 IGNORE_OVERLOAD_LIST = [
+    "th06::AnmVm::AnmVm",
     # This is supposed to be inlined but is inserted right before the first caller.
     "D3DXMatrixIdentity"
 ]

--- a/scripts/generate_detours.py
+++ b/scripts/generate_detours.py
@@ -44,7 +44,7 @@ def get_path_of_mangled_symbol(symbol):
 IGNORE_OVERLOAD_LIST = [
     "th06::AnmVm::AnmVm",
     # This is supposed to be inlined but is inserted right before the first caller.
-    "D3DXMatrixIdentity"
+    "D3DXMatrixIdentity",
 ]
 
 fun_to_mangled_map = {}

--- a/src/AnmManager.cpp
+++ b/src/AnmManager.cpp
@@ -30,8 +30,6 @@ D3DFORMAT g_TextureFormatD3D8Mapping[6] = {
 #define TEX_FMT_R8G8B8 4
 #define TEX_FMT_A4R4G4B4 5
 
-// Stack layout here doesn't match because of extra unused stack slot.
-// This might mean that some empty constructors are called and inlined here.
 AnmManager::AnmManager()
 {
     this->maybeLoadedSpriteCount = 0;

--- a/src/AnmVm.cpp
+++ b/src/AnmVm.cpp
@@ -27,8 +27,4 @@ void AnmVm::Initialize()
     this->currentTimeInScript.Initialize();
 }
 
-AnmVm::AnmVm()
-{
-    this->activeSpriteIndex = -1;
-}
 }; // namespace th06

--- a/src/AnmVm.hpp
+++ b/src/AnmVm.hpp
@@ -130,7 +130,10 @@ union AnmVmFlags {
 
 struct AnmVm
 {
-    AnmVm();
+    AnmVm()
+    {
+        this->activeSpriteIndex = -1;
+    }
 
     void Initialize();
     void SetInvisible()


### PR DESCRIPTION
`AnmVm`'s constructor actually appears to be have been defined inside of the struct definition rather than outside of it. Relocating it to be as such either matches or improves the accuracy of stack frame size in the constructors of other types that contain one or more `AnmVm` instances.

The comment on `AnmManager`'s constructor has been removed as the issues it described were caused by this discrepancy.