### PR TITLE
Cache ghidra obj in compare job

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -105,7 +105,13 @@ jobs:
       run: curl -L https://raw.githubusercontent.com/${{steps.workflow_run_info.outputs.head_repository_full_name}}/${{steps.workflow_run_info.outputs.head_sha}}/objdiff.json -o objdiff.json --fail
     - name: Use mapping.csv from target repo
       run: curl -L https://raw.githubusercontent.com/${{steps.workflow_run_info.outputs.head_repository_full_name}}/${{steps.workflow_run_info.outputs.head_sha}}/config/mapping.csv -o config/mapping.csv --fail
+    - uses: actions/cache@v4
+      id: ghidra-obj-cache
+      with:
+        path: build/objdiff/orig
+        key: ghidra-objs-${{ hashFiles('config/mapping.csv') }}
     - name: Generate objs using ghidra-delinker
+      if: steps.ghidra-obj-cache.outputs.cache-hit != 'true'
       run: python scripts/export_ghidra_objs.py --import-csv
     - name: Create diff summary
       run: python scripts/diff_all_functions.py --diff-method=objdiff > $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We can actually use `mapping.csv` as a cache key here. This should drastically accelerate the comparison step.