### PR TITLE
Miscellanous type-based improvements

### DIFF
--- a/src/BombData.cpp
+++ b/src/BombData.cpp
@@ -45,11 +45,11 @@ void BombData::BombReimuACalc(Player *player)
         g_ItemManager.RemoveAllItems();
         g_EffectManager.SpawnParticles(PARTICLE_EFFECT_UNK_12, &player->positionCenter, 1, COLOR_NEONBLUE);
 
-        player->bombProjectiles[8].pos.x = (player->positionCenter).x;
-        player->bombProjectiles[8].pos.y = (player->positionCenter).y;
+        player->bombProjectiles[8].posX = (player->positionCenter).x;
+        player->bombProjectiles[8].posY = (player->positionCenter).y;
 
-        player->bombProjectiles[8].size.x = 256.0f;
-        player->bombProjectiles[8].size.y = 256.0f;
+        player->bombProjectiles[8].sizeX = 256.0f;
+        player->bombProjectiles[8].sizeY = 256.0f;
     }
     if (player->bombInfo.timer >= 60 && player->bombInfo.timer < 180)
     {
@@ -126,11 +126,11 @@ void BombData::BombReimuACalc(Player *player)
                 player->bombRegionPositions[i] = player->bombInfo.bombRegionPositions[i];
                 player->bombRegionDamages[i] = 8;
 
-                player->bombProjectiles[i].pos.x = player->bombInfo.bombRegionPositions[i].x;
-                player->bombProjectiles[i].pos.y = player->bombInfo.bombRegionPositions[i].y;
+                player->bombProjectiles[i].posX = player->bombInfo.bombRegionPositions[i].x;
+                player->bombProjectiles[i].posY = player->bombInfo.bombRegionPositions[i].y;
 
-                player->bombProjectiles[i].size.x = 48.0f;
-                player->bombProjectiles[i].size.y = 48.0f;
+                player->bombProjectiles[i].sizeX = 48.0f;
+                player->bombProjectiles[i].sizeY = 48.0f;
 
                 if (player->unk_838[i] >= 100 || player->bombInfo.timer >= player->bombInfo.duration - 30)
                 {
@@ -150,8 +150,8 @@ void BombData::BombReimuACalc(Player *player)
 
                     player->bombRegionDamages[i] = 200;
 
-                    player->bombProjectiles[i].size.x = 256.0f;
-                    player->bombProjectiles[i].size.y = 256.0f;
+                    player->bombProjectiles[i].sizeX = 256.0f;
+                    player->bombProjectiles[i].sizeY = 256.0f;
 
                     player->bombInfo.bombRegionVelocities[i] / 100.0f; // ZUN moment
 
@@ -299,26 +299,26 @@ void BombData::BombReimuBCalc(Player *player)
             ScreenEffect::RegisterChain(SCREEN_EFFECT_SHAKE, 80, 20, 0, 0);
         }
 
-        player->bombProjectiles[0].size.x = 62.0f;
-        player->bombProjectiles[0].size.y = 448.0f;
-        player->bombProjectiles[1].size.x = 384.0f;
-        player->bombProjectiles[1].size.y = 62.0f;
-        player->bombProjectiles[2].size.x = 62.0f;
-        player->bombProjectiles[2].size.y = 448.0f;
-        player->bombProjectiles[3].size.x = 384.0f;
-        player->bombProjectiles[3].size.y = 62.0f;
+        player->bombProjectiles[0].sizeX = 62.0f;
+        player->bombProjectiles[0].sizeY = 448.0f;
+        player->bombProjectiles[1].sizeX = 384.0f;
+        player->bombProjectiles[1].sizeY = 62.0f;
+        player->bombProjectiles[2].sizeX = 62.0f;
+        player->bombProjectiles[2].sizeY = 448.0f;
+        player->bombProjectiles[3].sizeX = 384.0f;
+        player->bombProjectiles[3].sizeY = 62.0f;
 
         for (i = 0; i < 4; i++)
         {
             g_AnmManager->ExecuteScript(&player->bombInfo.sprites[0][i]);
             if (player->bombInfo.timer.HasTicked() && player->bombInfo.timer.AsFrames() % 2 != 0)
             {
-                player->bombProjectiles[i].pos.x =
+                player->bombProjectiles[i].posX =
                     player->bombInfo.bombRegionPositions[i].x + player->bombInfo.sprites[0][i].posOffset.x;
-                player->bombProjectiles[i].pos.y =
+                player->bombProjectiles[i].posY =
                     player->bombInfo.bombRegionPositions[i].y + player->bombInfo.sprites[0][i].posOffset.y;
-                player->bombRegionSizes[i].x = player->bombProjectiles[i].size.x;
-                player->bombRegionSizes[i].y = player->bombProjectiles[i].size.y;
+                player->bombRegionSizes[i].x = player->bombProjectiles[i].sizeX;
+                player->bombRegionSizes[i].y = player->bombProjectiles[i].sizeY;
                 player->bombRegionPositions[i] =
                     player->bombInfo.bombRegionPositions[i] + player->bombInfo.sprites[0][i].posOffset;
                 player->bombRegionDamages[i] = 8;
@@ -396,10 +396,10 @@ void BombData::BombMarisaACalc(Player *player)
 
             if (player->bombInfo.timer.HasTicked() && player->bombInfo.timer.AsFrames() % 3 != 0)
             {
-                player->bombProjectiles[i].pos.x = player->bombInfo.bombRegionPositions[i].x;
-                player->bombProjectiles[i].pos.y = player->bombInfo.bombRegionPositions[i].y;
-                player->bombProjectiles[i].size.x = 128.0f;
-                player->bombProjectiles[i].size.y = 128.0f;
+                player->bombProjectiles[i].posX = player->bombInfo.bombRegionPositions[i].x;
+                player->bombProjectiles[i].posY = player->bombInfo.bombRegionPositions[i].y;
+                player->bombProjectiles[i].sizeX = 128.0f;
+                player->bombProjectiles[i].sizeY = 128.0f;
                 player->bombRegionSizes[i].x = 128.0f;
                 player->bombRegionSizes[i].y = 128.0f;
 
@@ -504,14 +504,14 @@ void BombData::BombMarisaBCalc(Player *player)
 
         if (player->bombInfo.timer.HasTicked() && player->bombInfo.timer.AsFrames() % 4 != 0)
         {
-            player->bombProjectiles[0].pos.x = 192.0f;
-            player->bombProjectiles[0].pos.y = player->positionCenter.y / 2.0f;
-            player->bombProjectiles[0].size.x = 384.0f;
-            player->bombProjectiles[0].size.y = player->positionCenter.y;
+            player->bombProjectiles[0].posX = 192.0f;
+            player->bombProjectiles[0].posY = player->positionCenter.y / 2.0f;
+            player->bombProjectiles[0].sizeX = 384.0f;
+            player->bombProjectiles[0].sizeY = player->positionCenter.y;
             player->bombRegionSizes[0].x = 384.0f;
             player->bombRegionSizes[0].y = player->positionCenter.y;
-            player->bombRegionPositions[0].x = player->bombProjectiles[0].pos.x;
-            player->bombRegionPositions[0].y = player->bombProjectiles[0].pos.y;
+            player->bombRegionPositions[0].x = player->bombProjectiles[0].posX;
+            player->bombRegionPositions[0].y = player->bombProjectiles[0].posY;
             player->bombRegionDamages[0] = 12;
         }
 

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -774,7 +774,7 @@ void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr)
         effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 40.0f - 20.0f) / 60.0f;
         effect->unk_11c.y = (8.0f * baseAngleModifier) / 60.0f - (4.0f / 15.0f);
         effect->unk_11c.z = 0.0;
-        effect->unk_128 = -effect->unk_11c * invertf(120.0f);
+        effect->unk_128 = -effect->unk_11c / RECIPROCAL(120.0f);
 
         particlePos = enemy->position;
         particlePos.x -= cosf(finalAngle) * distanceModifier;
@@ -783,7 +783,7 @@ void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr)
         effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 40.0f - 20.0f) / 60.0f;
         effect->unk_11c.y = (8.0f * baseAngleModifier) / 60.0f - (4.0f / 15.0f);
         effect->unk_11c.z = 0.0;
-        effect->unk_128 = -effect->unk_11c * invertf(120.0f);
+        effect->unk_128 = -effect->unk_11c / RECIPROCAL(120.0f);
     }
 
     enemy->exInsFunc6Timer.Tick();

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -774,7 +774,7 @@ void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr)
         effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 40.0f - 20.0f) / 60.0f;
         effect->unk_11c.y = (8.0f * baseAngleModifier) / 60.0f - (4.0f / 15.0f);
         effect->unk_11c.z = 0.0;
-        effect->unk_128 = -effect->unk_11c / RECIPROCAL(120.0f);
+        effect->unk_128 = -effect->unk_11c / 120.0f;
 
         particlePos = enemy->position;
         particlePos.x -= cosf(finalAngle) * distanceModifier;
@@ -783,7 +783,7 @@ void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr)
         effect->unk_11c.x = (g_Rng.GetRandomF32ZeroToOne() * 40.0f - 20.0f) / 60.0f;
         effect->unk_11c.y = (8.0f * baseAngleModifier) / 60.0f - (4.0f / 15.0f);
         effect->unk_11c.z = 0.0;
-        effect->unk_128 = -effect->unk_11c / RECIPROCAL(120.0f);
+        effect->unk_128 = -effect->unk_11c / 120.0f;
     }
 
     enemy->exInsFunc6Timer.Tick();

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1399,7 +1399,7 @@ void Player::ScoreGraze(D3DXVECTOR3 *center)
         }
     }
 
-    particlePosition = (this->positionCenter + *center) * invertf(2.0f);
+    particlePosition = (this->positionCenter + *center) / 0.5f;
     g_EffectManager.SpawnParticles(PARTICLE_EFFECT_UNK_8, &particlePosition, 1, COLOR_WHITE);
     g_GameManager.AddScore(500);
     g_GameManager.IncreaseSubrank(6);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1319,8 +1319,8 @@ i32 Player::CalcLaserHitbox(D3DXVECTOR3 *laserCenter, D3DXVECTOR3 *laserSize, D3
     playerRelativeTopLeft = laserTopLeft - this->hitboxSize;
     playerRelativeBottomRight = laserTopLeft + this->hitboxSize;
 
-    laserTopLeft = *laserCenter - *laserSize * invertf(2.0f);
-    laserBottomRight = *laserCenter + *laserSize * invertf(2.0f);
+    laserTopLeft = *laserCenter - *laserSize / 0.5;
+    laserBottomRight = *laserCenter + *laserSize / 0.5;
 
     if (!(playerRelativeTopLeft.x > laserBottomRight.x || playerRelativeBottomRight.x < laserTopLeft.x ||
           playerRelativeTopLeft.y > laserBottomRight.y || playerRelativeBottomRight.y < laserTopLeft.y))

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1319,8 +1319,8 @@ i32 Player::CalcLaserHitbox(D3DXVECTOR3 *laserCenter, D3DXVECTOR3 *laserSize, D3
     playerRelativeTopLeft = laserTopLeft - this->hitboxSize;
     playerRelativeBottomRight = laserTopLeft + this->hitboxSize;
 
-    laserTopLeft = *laserCenter - *laserSize / 0.5;
-    laserBottomRight = *laserCenter + *laserSize / 0.5;
+    laserTopLeft = *laserCenter - *laserSize / RECIPROCAL(2.0f);
+    laserBottomRight = *laserCenter + *laserSize / RECIPROCAL(2.0f);
 
     if (!(playerRelativeTopLeft.x > laserBottomRight.x || playerRelativeBottomRight.x < laserTopLeft.x ||
           playerRelativeTopLeft.y > laserBottomRight.y || playerRelativeBottomRight.y < laserTopLeft.y))
@@ -1399,7 +1399,7 @@ void Player::ScoreGraze(D3DXVECTOR3 *center)
         }
     }
 
-    particlePosition = (this->positionCenter + *center) / 0.5f;
+    particlePosition = (this->positionCenter + *center) / RECIPROCAL(2.0f);
     g_EffectManager.SpawnParticles(PARTICLE_EFFECT_UNK_8, &particlePosition, 1, COLOR_WHITE);
     g_GameManager.AddScore(500);
     g_GameManager.IncreaseSubrank(6);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1319,8 +1319,8 @@ i32 Player::CalcLaserHitbox(D3DXVECTOR3 *laserCenter, D3DXVECTOR3 *laserSize, D3
     playerRelativeTopLeft = laserTopLeft - this->hitboxSize;
     playerRelativeBottomRight = laserTopLeft + this->hitboxSize;
 
-    laserTopLeft = *laserCenter - *laserSize / RECIPROCAL(2.0f);
-    laserBottomRight = *laserCenter + *laserSize / RECIPROCAL(2.0f);
+    laserTopLeft = *laserCenter - *laserSize / 2.0f;
+    laserBottomRight = *laserCenter + *laserSize / 2.0f;
 
     if (!(playerRelativeTopLeft.x > laserBottomRight.x || playerRelativeBottomRight.x < laserTopLeft.x ||
           playerRelativeTopLeft.y > laserBottomRight.y || playerRelativeBottomRight.y < laserTopLeft.y))
@@ -1399,7 +1399,7 @@ void Player::ScoreGraze(D3DXVECTOR3 *center)
         }
     }
 
-    particlePosition = (this->positionCenter + *center) / RECIPROCAL(2.0f);
+    particlePosition = (this->positionCenter + *center) / 2.0f;
     g_EffectManager.SpawnParticles(PARTICLE_EFFECT_UNK_8, &particlePosition, 1, COLOR_WHITE);
     g_GameManager.AddScore(500);
     g_GameManager.IncreaseSubrank(6);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -165,7 +165,7 @@ ChainCallbackResult Player::OnUpdate(Player *p)
     }
     for (idx = 0; idx < ARRAY_SIZE_SIGNED(p->bombProjectiles); idx++)
     {
-        p->bombProjectiles[idx].size.x = 0.0;
+        p->bombProjectiles[idx].sizeX = 0.0;
     }
     if (p->bombInfo.isInUse)
     {
@@ -1222,15 +1222,15 @@ i32 Player::CheckGraze(D3DXVECTOR3 *center, D3DXVECTOR3 *size)
 
     for (i = 0; i < ARRAY_SIZE_SIGNED(this->bombProjectiles); i++, bombProjectile++)
     {
-        if (bombProjectile->size.x == 0.0f)
+        if (bombProjectile->sizeX == 0.0f)
         {
             continue;
         }
 
-        bombTopLeft.x = bombProjectile->pos.x - bombProjectile->size.x / 2.0f;
-        bombTopLeft.y = bombProjectile->pos.y - bombProjectile->size.y / 2.0f;
-        bombBottomRight.x = bombProjectile->size.x / 2.0f + bombProjectile->pos.x;
-        bombBottomRight.y = bombProjectile->size.y / 2.0f + bombProjectile->pos.y;
+        bombTopLeft.x = bombProjectile->posX - bombProjectile->sizeX / 2.0f;
+        bombTopLeft.y = bombProjectile->posY - bombProjectile->sizeY / 2.0f;
+        bombBottomRight.x = bombProjectile->sizeX / 2.0f + bombProjectile->posX;
+        bombBottomRight.y = bombProjectile->sizeY / 2.0f + bombProjectile->posY;
 
         // Bomb clips bullet's hitbox, destroys bullet upon return
         if (!(bombTopLeft.x > bulletBottomRight.x || bombBottomRight.x < bulletTopLeft.x ||
@@ -1273,14 +1273,14 @@ i32 Player::CalcKillBoxCollision(D3DXVECTOR3 *bulletCenter, D3DXVECTOR3 *bulletS
     bulletBottom = bulletCenter->y + bulletSize->y / 2.0f;
     for (curBombIdx = 0; curBombIdx < ARRAY_SIZE_SIGNED(this->bombProjectiles); curBombIdx++, curBombProjectile++)
     {
-        if (curBombProjectile->size.x == 0.0f)
+        if (curBombProjectile->sizeX == 0.0f)
         {
             continue;
         }
-        bombProjectileLeft = curBombProjectile->pos.x - curBombProjectile->size.x / 2.0f;
-        bombProjectileTop = curBombProjectile->pos.y - curBombProjectile->size.y / 2.0f;
-        bombProjectileRight = curBombProjectile->pos.x + curBombProjectile->size.x / 2.0f;
-        bombProjectileBottom = curBombProjectile->pos.y + curBombProjectile->size.y / 2.0f;
+        bombProjectileLeft = curBombProjectile->posX - curBombProjectile->sizeX / 2.0f;
+        bombProjectileTop = curBombProjectile->posY - curBombProjectile->sizeY / 2.0f;
+        bombProjectileRight = curBombProjectile->posX + curBombProjectile->sizeX / 2.0f;
+        bombProjectileBottom = curBombProjectile->posY + curBombProjectile->sizeY / 2.0f;
         if (!(bombProjectileLeft > bulletRight || bombProjectileRight < bulletLeft ||
               bombProjectileTop > bulletBottom || bombProjectileBottom < bulletTop))
         {

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -74,8 +74,10 @@ enum BulletState
 };
 struct PlayerRect
 {
-    D3DXVECTOR2 pos;
-    D3DXVECTOR2 size;
+    f32 posX;
+    f32 posY;
+    f32 sizeX;
+    f32 sizeY;
 };
 C_ASSERT(sizeof(PlayerRect) == 0x10);
 

--- a/src/ZunMath.hpp
+++ b/src/ZunMath.hpp
@@ -3,8 +3,6 @@
 #include <Windows.h>
 #include <d3dx8math.h>
 
-#define RECIPROCAL(x) (1.0f / x)
-
 struct ZunVec2
 {
     f32 x;
@@ -87,4 +85,9 @@ void __inline sincosmul(D3DXVECTOR3 *out_vel, f32 input, f32 multiplier)
         fmul [multiplier]
         fstp [eax+4]
     }
+}
+
+f32 __inline invertf(f32 x)
+{
+    return 1.f / x;
 }

--- a/src/ZunMath.hpp
+++ b/src/ZunMath.hpp
@@ -3,6 +3,8 @@
 #include <Windows.h>
 #include <d3dx8math.h>
 
+#define RECIPROCAL(x) (1.0f / x)
+
 struct ZunVec2
 {
     f32 x;

--- a/src/ZunMath.hpp
+++ b/src/ZunMath.hpp
@@ -88,8 +88,3 @@ void __inline sincosmul(D3DXVECTOR3 *out_vel, f32 input, f32 multiplier)
         fstp [eax+4]
     }
 }
-
-f32 __inline invertf(f32 x)
-{
-    return 1.f / x;
-}


### PR DESCRIPTION
Most of the improvements in this PR come from the replacement of the `invertf()` function with what it actually was, `D3DXVECTOR3::operator/` which calculates the reciprocal of the divisor and multiplies the vector by that. Additionally, it would appear that the cause of the mismatch in `Player::Player` was because of  `PlayerRect` not actually using `D3DXVECTOR2`, hence the erroneous presence of its constructor.

- Match Player::Player
- Match EnemyEclInstr::ExInsStage6XFunc6
- Match Player::CalcLaserHitbox
- Match Player::ScoreGraze