### PR TITLE
Match Enemy::ResetEffectArray and Enemy::UpdateEffects

### DIFF
--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -250,7 +250,7 @@ struct Enemy
     D3DXVECTOR2 lowerMoveLimit;
     D3DXVECTOR2 upperMoveLimit;
     Effect *effectArray[12];
-    u32 effectIdx;
+    i32 effectIdx;
     f32 effectDistance;
     i32 lifeCallbackThreshold;
     i32 lifeCallbackSub;


### PR DESCRIPTION
`Enemy.effectIdx` had the wrong type. Unsure how we didn't catch this sooner.