### PR TITLE
Miscellaneous typo fixes

### DIFF
--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -29,7 +29,7 @@ struct PatchouliShottypeVars
 C_ASSERT(sizeof(PatchouliShottypeVars) == 0x18);
 
 DIFFABLE_STATIC_ARRAY_ASSIGN(PatchouliShottypeVars, 2, g_PatchouliShottypeVars) = {{{{0, 3, 1}, {2, 3, 4}}},
-                                                                                   {{{1, 4, 0}, {4, 2, 4}}}};
+                                                                                   {{{1, 4, 0}, {4, 2, 3}}}};
 DIFFABLE_STATIC(i32, g_PlayerShot);
 DIFFABLE_STATIC(f32, g_PlayerDistance);
 DIFFABLE_STATIC(f32, g_PlayerAngle);

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -45,8 +45,8 @@ void MoveDirTime(Enemy *enemy, EclRawInstr *instr)
     alu = &instr->args.alu;
     angle = *GetVarFloat(enemy, &alu->arg1.f32, NULL);
 
-    enemy->moveInterp.x = sinf(angle) * alu->arg2.f32 * alu->res / 2.0f;
-    enemy->moveInterp.y = cosf(angle) * alu->arg2.f32 * alu->res / 2.0f;
+    enemy->moveInterp.x = cosf(angle) * alu->arg2.f32 * alu->res / 2.0f;
+    enemy->moveInterp.y = sinf(angle) * alu->arg2.f32 * alu->res / 2.0f;
     enemy->moveInterp.z = 0.0f;
 
     enemy->moveInterpStartPos = enemy->position;

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -84,8 +84,8 @@ void MoveTime(Enemy *enemy, EclRawInstr *instr)
     alu = &instr->args.alu;
     angle = *GetVarFloat(enemy, &enemy->angle, NULL);
 
-    enemy->moveInterp.x = sinf(angle) * enemy->speed * alu->res / 2.0f;
-    enemy->moveInterp.y = cosf(angle) * enemy->speed * alu->res / 2.0f;
+    enemy->moveInterp.x = cosf(angle) * enemy->speed * alu->res / 2.0f;
+    enemy->moveInterp.y = sinf(angle) * enemy->speed * alu->res / 2.0f;
     enemy->moveInterp.z = 0.0f;
 
     enemy->moveInterpStartPos = enemy->position;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -26,7 +26,7 @@ DIFFABLE_STATIC(Player, g_Player);
 
 DIFFABLE_STATIC_ARRAY_ASSIGN(CharacterData, 4, g_CharData) = {
     /* ReimuA  */ {4.0, 2.0, 4.0, 2.0, Player::FireBulletReimuA, Player::FireBulletReimuA},
-    /* ReimuB  */ {4.0, 2.0, 4.0, 2.0, Player::FireBulletReimuA, Player::FireBulletReimuB},
+    /* ReimuB  */ {4.0, 2.0, 4.0, 2.0, Player::FireBulletReimuB, Player::FireBulletReimuB},
     /* MarisaA */ {5.0, 2.5, 5.0, 2.5, Player::FireBulletMarisaA, Player::FireBulletMarisaA},
     /* MarisaB */ {5.0, 2.5, 5.0, 2.5, Player::FireBulletMarisaB, Player::FireBulletMarisaB},
 };


### PR DESCRIPTION
Corrects a few cases where global variables have the wrong value or the wrong function is referenced. This fixes enemy movement, gets Reimu B's shot to work when unfocused, and fixes Patchouli's behaviour.