### PR TITLE
Fix function signatures for GameErrorContext methods

### DIFF
--- a/src/AnmManager.cpp
+++ b/src/AnmManager.cpp
@@ -241,7 +241,7 @@ ZunResult AnmManager::LoadTextureAlphaChannel(i32 textureIdx, char *textureName,
     if (surfaceDesc.Format != D3DFMT_A8R8G8B8 && surfaceDesc.Format != D3DFMT_A4R4G4B4 &&
         surfaceDesc.Format != D3DFMT_A1R5G5B5)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_ANMMANAGER_UNK_TEX_FORMAT);
+        g_GameErrorContext.Fatal(TH_ERR_ANMMANAGER_UNK_TEX_FORMAT);
         goto err;
     }
 
@@ -344,7 +344,7 @@ ZunResult AnmManager::LoadAnm(i32 anmIdx, char *path, i32 spriteIdxOffset)
 
     if (anm == NULL)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_ANMMANAGER_SPRITE_CORRUPTED, path);
+        g_GameErrorContext.Fatal(TH_ERR_ANMMANAGER_SPRITE_CORRUPTED, path);
         return ZUN_ERROR;
     }
 
@@ -358,7 +358,7 @@ ZunResult AnmManager::LoadAnm(i32 anmIdx, char *path, i32 spriteIdxOffset)
     }
     else if (this->LoadTexture(anm->textureIdx, anmName, anm->format, anm->colorKey) != ZUN_SUCCESS)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_ANMMANAGER_TEXTURE_CORRUPTED, anmName);
+        g_GameErrorContext.Fatal(TH_ERR_ANMMANAGER_TEXTURE_CORRUPTED, anmName);
         return ZUN_ERROR;
     }
 
@@ -367,7 +367,7 @@ ZunResult AnmManager::LoadAnm(i32 anmIdx, char *path, i32 spriteIdxOffset)
         anmName = (char *)((u8 *)anm + anm->mipmapNameOffset);
         if (this->LoadTextureAlphaChannel(anm->textureIdx, anmName, anm->format, anm->colorKey) != ZUN_SUCCESS)
         {
-            GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_ANMMANAGER_TEXTURE_CORRUPTED, anmName);
+            g_GameErrorContext.Fatal(TH_ERR_ANMMANAGER_TEXTURE_CORRUPTED, anmName);
             return ZUN_ERROR;
         }
     }
@@ -1459,7 +1459,7 @@ ZunResult AnmManager::LoadSurface(i32 surfaceIdx, char *path)
     u8 *data = FileSystem::OpenPath(path, 0);
     if (data == NULL)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_CANNOT_BE_LOADED, path);
+        g_GameErrorContext.Fatal(TH_ERR_CANNOT_BE_LOADED, path);
         return ZUN_ERROR;
     }
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -19,7 +19,7 @@ u16 Controller::GetJoystickCaps(void)
 
     if (joyGetPosEx(0, &pji) != MMSYSERR_NOERROR)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_PAD_FOUND);
+        g_GameErrorContext.Log(TH_ERR_NO_PAD_FOUND);
         return 1;
     }
 

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -41,7 +41,7 @@ ZunResult EclManager::Load(char *eclPath)
     this->eclFile = (EclRawHeader *)FileSystem::OpenPath(eclPath, false);
     if (this->eclFile == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_ECLMANAGER_ENEMY_DATA_CORRUPT);
+        g_GameErrorContext.Log(TH_ERR_ECLMANAGER_ENEMY_DATA_CORRUPT);
         return ZUN_ERROR;
     }
     this->eclFile->timelineOffsets[0] =

--- a/src/Ending.cpp
+++ b/src/Ending.cpp
@@ -434,7 +434,7 @@ ZunResult Ending::LoadEnding(char *endFilePath)
     this->endFileData = (char *)FileSystem::OpenPath(endFilePath, false);
     if (this->endFileData == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_ENDING_END_FILE_CORRUPTED);
+        g_GameErrorContext.Log(TH_ERR_ENDING_END_FILE_CORRUPTED);
         return ZUN_ERROR;
     }
     else

--- a/src/GameErrorContext.cpp
+++ b/src/GameErrorContext.cpp
@@ -9,7 +9,7 @@ namespace th06
 DIFFABLE_STATIC(GameErrorContext, g_GameErrorContext)
 DIFFABLE_STATIC(CMyFont, g_CMyFont)
 
-const char *GameErrorContext::Log(GameErrorContext *ctx, const char *fmt, ...)
+const char *GameErrorContext::Log(const char *fmt, ...)
 {
     char tmpBuffer[512];
     size_t tmpBufferSize;
@@ -20,12 +20,12 @@ const char *GameErrorContext::Log(GameErrorContext *ctx, const char *fmt, ...)
 
     tmpBufferSize = strlen(tmpBuffer);
 
-    if (ctx->m_BufferEnd + tmpBufferSize < &ctx->m_Buffer[sizeof(ctx->m_Buffer) - 1])
+    if (this->m_BufferEnd + tmpBufferSize < &this->m_Buffer[sizeof(this->m_Buffer) - 1])
     {
-        strcpy(ctx->m_BufferEnd, tmpBuffer);
+        strcpy(this->m_BufferEnd, tmpBuffer);
 
-        ctx->m_BufferEnd += tmpBufferSize;
-        *ctx->m_BufferEnd = '\0';
+        this->m_BufferEnd += tmpBufferSize;
+        *this->m_BufferEnd = '\0';
     }
 
     va_end(args);
@@ -33,7 +33,7 @@ const char *GameErrorContext::Log(GameErrorContext *ctx, const char *fmt, ...)
     return fmt;
 }
 
-const char *GameErrorContext::Fatal(GameErrorContext *ctx, const char *fmt, ...)
+const char *GameErrorContext::Fatal(const char *fmt, ...)
 {
     char tmpBuffer[512];
     size_t tmpBufferSize;
@@ -44,17 +44,17 @@ const char *GameErrorContext::Fatal(GameErrorContext *ctx, const char *fmt, ...)
 
     tmpBufferSize = strlen(tmpBuffer);
 
-    if (ctx->m_BufferEnd + tmpBufferSize < &ctx->m_Buffer[sizeof(ctx->m_Buffer) - 1])
+    if (this->m_BufferEnd + tmpBufferSize < &this->m_Buffer[sizeof(this->m_Buffer) - 1])
     {
-        strcpy(ctx->m_BufferEnd, tmpBuffer);
+        strcpy(this->m_BufferEnd, tmpBuffer);
 
-        ctx->m_BufferEnd += tmpBufferSize;
-        *ctx->m_BufferEnd = '\0';
+        this->m_BufferEnd += tmpBufferSize;
+        *this->m_BufferEnd = '\0';
     }
 
     va_end(args);
 
-    ctx->m_ShowMessageBox = true;
+    this->m_ShowMessageBox = true;
 
     return fmt;
 }
@@ -65,7 +65,7 @@ void GameErrorContext::Flush()
 
     if (m_BufferEnd != m_Buffer)
     {
-        GameErrorContext::Log(this, TH_ERR_LOGGER_END);
+        g_GameErrorContext.Log(TH_ERR_LOGGER_END);
 
         if (m_ShowMessageBox)
         {

--- a/src/GameErrorContext.hpp
+++ b/src/GameErrorContext.hpp
@@ -23,7 +23,7 @@ class GameErrorContext
         m_Buffer[0] = '\0';
         // Required to get some mov eax, [m_Buffer_ptr]
         m_ShowMessageBox = false;
-        Log(this, TH_ERR_LOGGER_START);
+        Log(TH_ERR_LOGGER_START);
     }
 
     ~GameErrorContext()
@@ -39,8 +39,8 @@ class GameErrorContext
 
     void Flush();
 
-    static const char *Fatal(GameErrorContext *ctx, const char *fmt, ...);
-    static const char *Log(GameErrorContext *ctx, const char *fmt, ...);
+    const char *Fatal(const char *fmt, ...);
+    const char *Log(const char *fmt, ...);
 };
 
 DIFFABLE_EXTERN(GameErrorContext, g_GameErrorContext)

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -404,39 +404,39 @@ ZunResult GameManager::AddedCallback(GameManager *mgr)
     mgr->randomSeed = g_Rng.seed;
     if (Stage::RegisterChain(mgr->currentStage) != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_STAGE);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_STAGE);
         return ZUN_ERROR;
     }
 
     if (Player::RegisterChain(0) != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_PLAYER);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_PLAYER);
         return ZUN_ERROR;
     }
     if (BulletManager::RegisterChain("data/etama.anm") != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_BULLETMANAGER);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_BULLETMANAGER);
         return ZUN_ERROR;
     }
     if (EnemyManager::RegisterChain(g_AnmStageFiles[mgr->currentStage].file1,
                                     g_AnmStageFiles[mgr->currentStage].file2) != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_ENEMYMANAGER);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_ENEMYMANAGER);
         return ZUN_ERROR;
     }
     if (g_EclManager.Load(g_EclFiles[mgr->currentStage]) != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_ECLMANAGER);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_ECLMANAGER);
         return ZUN_ERROR;
     }
     if (EffectManager::RegisterChain() != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_EFFECTMANAGER);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_EFFECTMANAGER);
         return ZUN_ERROR;
     }
     if (Gui::RegisterChain() != ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_GUI);
+        g_GameErrorContext.Log(TH_ERR_GAMEMANAGER_FAILED_TO_INITIALIZE_GUI);
         return ZUN_ERROR;
     }
     if (g_GameManager.isInReplay == 0)

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -176,7 +176,7 @@ i32 GameWindow::InitD3dInterface(void)
 
     if (g_Supervisor.d3dIface == NULL)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_D3D_ERR_COULD_NOT_CREATE_OBJ);
+        g_GameErrorContext.Fatal(TH_ERR_D3D_ERR_COULD_NOT_CREATE_OBJ);
         return 1;
     }
     return 0;
@@ -296,13 +296,13 @@ i32 GameWindow::InitD3dRendering(void)
             {
                 present_params.BackBufferFormat = D3DFMT_X8R8G8B8;
                 g_Supervisor.cfg.colorMode16bit = 0;
-                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_SCREEN_INIT_32BITS);
+                g_GameErrorContext.Log(TH_ERR_SCREEN_INIT_32BITS);
             }
             else
             {
                 present_params.BackBufferFormat = D3DFMT_R5G6B5;
                 g_Supervisor.cfg.colorMode16bit = 1;
-                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_SCREEN_INIT_16BITS);
+                g_GameErrorContext.Log(TH_ERR_SCREEN_INIT_16BITS);
             }
         }
         else if (g_Supervisor.cfg.colorMode16bit == 0)
@@ -321,7 +321,7 @@ i32 GameWindow::InitD3dRendering(void)
         {
             present_params.FullScreen_RefreshRateInHz = 60;
             present_params.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_ONE;
-            GameErrorContext::Log(&g_GameErrorContext, TH_ERR_SET_REFRESH_RATE_60HZ);
+            g_GameErrorContext.Log(TH_ERR_SET_REFRESH_RATE_60HZ);
         }
         if (g_Supervisor.cfg.frameskipConfig == 0)
         {
@@ -357,12 +357,12 @@ i32 GameWindow::InitD3dRendering(void)
                                                     D3DCREATE_HARDWARE_VERTEXPROCESSING, &present_params,
                                                     &g_Supervisor.d3dDevice) < 0)
             {
-                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_TL_HAL_UNAVAILABLE);
+                g_GameErrorContext.Log(TH_ERR_TL_HAL_UNAVAILABLE);
                 if (g_Supervisor.d3dIface->CreateDevice(0, D3DDEVTYPE_HAL, g_GameWindow.window,
                                                         D3DCREATE_SOFTWARE_VERTEXPROCESSING, &present_params,
                                                         &g_Supervisor.d3dDevice) < 0)
                 {
-                    GameErrorContext::Log(&g_GameErrorContext, TH_ERR_HAL_UNAVAILABLE);
+                    g_GameErrorContext.Log(TH_ERR_HAL_UNAVAILABLE);
                 REFERENCE_RASTERIZER_MODE:
                     if (g_Supervisor.d3dIface->CreateDevice(0, D3DDEVTYPE_REF, g_GameWindow.window,
                                                             D3DCREATE_SOFTWARE_VERTEXPROCESSING, &present_params,
@@ -370,7 +370,7 @@ i32 GameWindow::InitD3dRendering(void)
                     {
                         if (((g_Supervisor.cfg.opts >> GCOS_FORCE_60FPS) & 1) != 0 && !g_Supervisor.vsyncEnabled)
                         {
-                            GameErrorContext::Log(&g_GameErrorContext, TH_ERR_CANT_CHANGE_REFRESH_RATE_FORCE_VSYNC);
+                            g_GameErrorContext.Log(TH_ERR_CANT_CHANGE_REFRESH_RATE_FORCE_VSYNC);
                             present_params.FullScreen_RefreshRateInHz = 0;
                             g_Supervisor.vsyncEnabled = 1;
                             present_params.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
@@ -380,14 +380,14 @@ i32 GameWindow::InitD3dRendering(void)
                         {
                             if (present_params.Flags == D3DPRESENTFLAG_LOCKABLE_BACKBUFFER)
                             {
-                                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_BACKBUFFER_NONLOCKED);
+                                g_GameErrorContext.Log(TH_ERR_BACKBUFFER_NONLOCKED);
                                 present_params.Flags = 0;
                                 g_Supervisor.lockableBackbuffer = 0;
                                 continue;
                             }
                             else
                             {
-                                GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_D3D_INIT_FAILED);
+                                g_GameErrorContext.Fatal(TH_ERR_D3D_INIT_FAILED);
                                 if (g_Supervisor.d3dIface != NULL)
                                 {
                                     g_Supervisor.d3dIface->Release();
@@ -399,20 +399,20 @@ i32 GameWindow::InitD3dRendering(void)
                     }
                     else
                     {
-                        GameErrorContext::Log(&g_GameErrorContext, TH_USING_REF_MODE);
+                        g_GameErrorContext.Log(TH_USING_REF_MODE);
                         g_Supervisor.hasD3dHardwareVertexProcessing = 0;
                         using_d3d_hal = 0;
                     }
                 }
                 else
                 {
-                    GameErrorContext::Log(&g_GameErrorContext, TH_USING_HAL_MODE);
+                    g_GameErrorContext.Log(TH_USING_HAL_MODE);
                     g_Supervisor.hasD3dHardwareVertexProcessing = 0;
                 }
             }
             else
             {
-                GameErrorContext::Log(&g_GameErrorContext, TH_USING_TL_HAL_MODE);
+                g_GameErrorContext.Log(TH_USING_TL_HAL_MODE);
                 g_Supervisor.hasD3dHardwareVertexProcessing = 1;
             }
             break;
@@ -442,13 +442,13 @@ i32 GameWindow::InitD3dRendering(void)
     if (((((g_Supervisor.cfg.opts >> GCOS_USE_D3D_HW_TEXTURE_BLENDING) & 1) == 0) &&
          ((g_Supervisor.d3dCaps.TextureOpCaps & D3DTEXOPCAPS_ADD) == 0)))
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_SUPPORT_FOR_D3DTEXOPCAPS_ADD);
+        g_GameErrorContext.Log(TH_ERR_NO_SUPPORT_FOR_D3DTEXOPCAPS_ADD);
         g_Supervisor.cfg.opts = g_Supervisor.cfg.opts | (1 << GCOS_USE_D3D_HW_TEXTURE_BLENDING);
     }
     if (g_Supervisor.ShouldRunAt60Fps() &&
         ((g_Supervisor.d3dCaps.PresentationIntervals & D3DPRESENT_INTERVAL_IMMEDIATE) == 0))
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_CANT_FORCE_60FPS_NO_ASYNC_FLIP);
+        g_GameErrorContext.Log(TH_ERR_CANT_FORCE_60FPS_NO_ASYNC_FLIP);
         g_Supervisor.cfg.opts = g_Supervisor.cfg.opts & ~(1 << GCOS_FORCE_60FPS);
     }
     if ((((g_Supervisor.cfg.opts >> GCOS_FORCE_16BIT_COLOR_MODE) & 1) == 0) && (using_d3d_hal != 0))
@@ -462,7 +462,7 @@ i32 GameWindow::InitD3dRendering(void)
         {
             g_Supervisor.colorMode16Bits = 0;
             g_Supervisor.cfg.opts = g_Supervisor.cfg.opts | (1 << GCOS_FORCE_16BIT_COLOR_MODE);
-            GameErrorContext::Log(&g_GameErrorContext, TH_ERR_D3DFMT_A8R8G8B8_UNSUPPORTED);
+            g_GameErrorContext.Log(TH_ERR_D3DFMT_A8R8G8B8_UNSUPPORTED);
         }
     }
     InitD3dDevice();

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -462,7 +462,7 @@ ZunResult Gui::LoadMsg(char *path)
     this->impl->msg.msgFile = (MsgRawHeader *)FileSystem::OpenPath(path, 0);
     if (this->impl->msg.msgFile == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_GUI_MSG_FILE_CORRUPTED, path);
+        g_GameErrorContext.Log(TH_ERR_GUI_MSG_FILE_CORRUPTED, path);
         return ZUN_ERROR;
     }
     this->impl->msg.currentMsgIdx = 0xffffffff;

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -278,7 +278,7 @@ ChainCallbackResult MainMenu::OnUpdate(MainMenu *menu)
         {
             if (LoadDiffCharSelect(menu) != ZUN_SUCCESS)
             {
-                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_MAINMENU_LOAD_SELECT_SCREEN_FAILED);
+                g_GameErrorContext.Log(TH_ERR_MAINMENU_LOAD_SELECT_SCREEN_FAILED);
                 g_Supervisor.curState = SUPERVISOR_STATE_EXITSUCCESS;
                 return CHAIN_CALLBACK_RESULT_CONTINUE_AND_REMOVE_JOB;
             }
@@ -1278,7 +1278,7 @@ i32 MainMenu::ReplayHandling()
         {
             if (LoadReplayMenu(this))
             {
-                GameErrorContext::Log(&g_GameErrorContext, "japanese");
+                g_GameErrorContext.Log("japanese");
                 g_Supervisor.curState = SUPERVISOR_STATE_EXITSUCCESS;
                 return ZUN_SUCCESS;
             }

--- a/src/MidiOutput.cpp
+++ b/src/MidiOutput.cpp
@@ -230,7 +230,7 @@ ZunResult MidiOutput::ReadFileData(u32 idx, char *path)
 
     if (this->midiFileData[idx] == (byte *)0x0)
     {
-        g_GameErrorContext.Log(&g_GameErrorContext, TH_ERR_MIDI_FAILED_TO_READ_FILE, path);
+        g_GameErrorContext.Log(TH_ERR_MIDI_FAILED_TO_READ_FILE, path);
         return ZUN_ERROR;
     }
 

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -299,8 +299,7 @@ ZunResult SoundPlayer::InitSoundBuffers()
         {
             if (this->LoadSound(idx, g_SFXList[idx]) != ZUN_SUCCESS)
             {
-                g_GameErrorContext.Log(TH_ERR_SOUNDPLAYER_FAILED_TO_LOAD_SOUND_FILE,
-                                      g_SFXList[idx]);
+                g_GameErrorContext.Log(TH_ERR_SOUNDPLAYER_FAILED_TO_LOAD_SOUND_FILE, g_SFXList[idx]);
                 return ZUN_ERROR;
             }
         }

--- a/src/SoundPlayer.cpp
+++ b/src/SoundPlayer.cpp
@@ -54,7 +54,7 @@ ZunResult SoundPlayer::InitializeDSound(HWND gameWindow)
     this->manager = new CSoundManager();
     if (this->manager->Initialize(gameWindow, 2, 2, 44100, 16) < ZUN_SUCCESS)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_SOUNDPLAYER_FAILED_TO_INITIALIZE_OBJECT);
+        g_GameErrorContext.Log(TH_ERR_SOUNDPLAYER_FAILED_TO_INITIALIZE_OBJECT);
         if (this->manager != NULL)
         {
             delete this->manager;
@@ -94,7 +94,7 @@ ZunResult SoundPlayer::InitializeDSound(HWND gameWindow)
     /* 4 times per second */
     SetTimer(gameWindow, 0, 250, NULL);
     this->gameWindow = gameWindow;
-    GameErrorContext::Log(&g_GameErrorContext, TH_DBG_SOUNDPLAYER_INIT_SUCCESS);
+    g_GameErrorContext.Log(TH_DBG_SOUNDPLAYER_INIT_SUCCESS);
     return ZUN_SUCCESS;
 }
 
@@ -299,7 +299,7 @@ ZunResult SoundPlayer::InitSoundBuffers()
         {
             if (this->LoadSound(idx, g_SFXList[idx]) != ZUN_SUCCESS)
             {
-                GameErrorContext::Log(&g_GameErrorContext, TH_ERR_SOUNDPLAYER_FAILED_TO_LOAD_SOUND_FILE,
+                g_GameErrorContext.Log(TH_ERR_SOUNDPLAYER_FAILED_TO_LOAD_SOUND_FILE,
                                       g_SFXList[idx]);
                 return ZUN_ERROR;
             }
@@ -364,7 +364,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
     }
     if (strncmp((char *)sFDCursor, "RIFF", 4))
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NOT_A_WAV_FILE, path);
+        g_GameErrorContext.Log(TH_ERR_NOT_A_WAV_FILE, path);
         free(soundFileData);
         return ZUN_ERROR;
     }
@@ -375,7 +375,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
 
     if (strncmp((char *)sFDCursor, "WAVE", 4))
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NOT_A_WAV_FILE, path);
+        g_GameErrorContext.Log(TH_ERR_NOT_A_WAV_FILE, path);
         free(soundFileData);
         return ZUN_ERROR;
     }
@@ -383,7 +383,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
     wavDataPtr = GetWavFormatData(sFDCursor, "fmt ", &formatSize, fileSize - 12);
     if (wavDataPtr == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NOT_A_WAV_FILE, path);
+        g_GameErrorContext.Log(TH_ERR_NOT_A_WAV_FILE, path);
         free(soundFileData);
         return ZUN_ERROR;
     }
@@ -392,7 +392,7 @@ ZunResult SoundPlayer::LoadSound(i32 idx, char *path)
     wavDataPtr = GetWavFormatData(sFDCursor, "data", &formatSize, fileSize - 12);
     if (wavDataPtr == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NOT_A_WAV_FILE, path);
+        g_GameErrorContext.Log(TH_ERR_NOT_A_WAV_FILE, path);
         free(soundFileData);
         return ZUN_ERROR;
     }

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -412,7 +412,7 @@ ZunResult Stage::LoadStageData(char *anmpath, char *stdpath)
     this->stdData = (RawStageHeader *)FileSystem::OpenPath(stdpath, false);
     if (this->stdData == NULL)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_STAGE_DATA_CORRUPTED);
+        g_GameErrorContext.Log(TH_ERR_STAGE_DATA_CORRUPTED);
         return ZUN_ERROR;
     }
     this->objectsCount = this->stdData->nbObjects;

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -337,7 +337,7 @@ ZunResult Supervisor::AddedCallback(Supervisor *s)
 
     if (AsciiManager::RegisterChain() != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_ASCIIMANAGER_INIT_FAILED);
+        g_GameErrorContext.Log(TH_ERR_ASCIIMANAGER_INIT_FAILED);
         return ZUN_ERROR;
     }
 
@@ -365,7 +365,7 @@ ZunResult Supervisor::SetupDInput(Supervisor *supervisor)
         0)
     {
         supervisor->dinputIface = NULL;
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DIRECTINPUT_NOT_AVAILABLE);
+        g_GameErrorContext.Log(TH_ERR_DIRECTINPUT_NOT_AVAILABLE);
         return ZUN_ERROR;
     }
 
@@ -376,7 +376,7 @@ ZunResult Supervisor::SetupDInput(Supervisor *supervisor)
             supervisor->dinputIface->Release();
             supervisor->dinputIface = NULL;
         }
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DIRECTINPUT_NOT_AVAILABLE);
+        g_GameErrorContext.Log(TH_ERR_DIRECTINPUT_NOT_AVAILABLE);
         return ZUN_ERROR;
     }
 
@@ -394,7 +394,7 @@ ZunResult Supervisor::SetupDInput(Supervisor *supervisor)
             supervisor->dinputIface = NULL;
         }
 
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DIRECTINPUT_SETDATAFORMAT_NOT_AVAILABLE);
+        g_GameErrorContext.Log(TH_ERR_DIRECTINPUT_SETDATAFORMAT_NOT_AVAILABLE);
         return ZUN_ERROR;
     }
 
@@ -413,12 +413,12 @@ ZunResult Supervisor::SetupDInput(Supervisor *supervisor)
             supervisor->dinputIface = NULL;
         }
 
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DIRECTINPUT_SETCOOPERATIVELEVEL_NOT_AVAILABLE);
+        g_GameErrorContext.Log(TH_ERR_DIRECTINPUT_SETCOOPERATIVELEVEL_NOT_AVAILABLE);
         return ZUN_ERROR;
     }
 
     supervisor->keyboard->Acquire();
-    GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DIRECTINPUT_INITIALIZED);
+    g_GameErrorContext.Log(TH_ERR_DIRECTINPUT_INITIALIZED);
 
     supervisor->dinputIface->EnumDevices(DI8DEVCLASS_GAMECTRL, Supervisor::EnumGameControllersCb, NULL,
                                          DIEDFL_ATTACHEDONLY);
@@ -432,7 +432,7 @@ ZunResult Supervisor::SetupDInput(Supervisor *supervisor)
         supervisor->controller->GetCapabilities(&g_Supervisor.controllerCaps);
         supervisor->controller->EnumObjects(Supervisor::ControllerCallback, NULL, DIDFT_ALL);
 
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_PAD_FOUND);
+        g_GameErrorContext.Log(TH_ERR_PAD_FOUND);
     }
     return ZUN_SUCCESS;
 }
@@ -599,7 +599,7 @@ i32 Supervisor::LoadPbg3(i32 pbg3FileIdx, char *filename)
             i32 res = this->pbg3Archives[pbg3FileIdx]->FindEntry(verPath);
             if (res < 0)
             {
-                GameErrorContext::Fatal(&g_GameErrorContext, "error : データのバージョンが違います\n");
+                g_GameErrorContext.Fatal("error : データのバージョンが違います\n");
                 return 1;
             }
         }
@@ -651,7 +651,7 @@ ZunResult Supervisor::LoadConfig(char *path)
         g_Supervisor.cfg.windowed = false;
         g_Supervisor.cfg.frameskipConfig = 0;
         g_Supervisor.cfg.controllerMapping = g_ControllerMapping;
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_CONFIG_NOT_FOUND);
+        g_GameErrorContext.Log(TH_ERR_CONFIG_NOT_FOUND);
     }
     else
     {
@@ -686,64 +686,64 @@ ZunResult Supervisor::LoadConfig(char *path)
             g_Supervisor.cfg.controllerMapping = g_ControllerMapping;
             memset(&g_Supervisor.cfg.opts, 0, sizeof(GameConfigOptsShifts));
             g_Supervisor.cfg.opts |= (1 << GCOS_USE_D3D_HW_TEXTURE_BLENDING);
-            GameErrorContext::Log(&g_GameErrorContext, TH_ERR_CONFIG_CORRUPTED);
+            g_GameErrorContext.Log(TH_ERR_CONFIG_CORRUPTED);
         }
         g_ControllerMapping = g_Supervisor.cfg.controllerMapping;
         free(data);
     }
     if (((this->cfg.opts >> GCOS_DONT_USE_VERTEX_BUF) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_VERTEX_BUFFER);
+        g_GameErrorContext.Log(TH_ERR_NO_VERTEX_BUFFER);
     }
     if (((this->cfg.opts >> GCOS_DONT_USE_FOG) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_FOG);
+        g_GameErrorContext.Log(TH_ERR_NO_FOG);
     }
     if (((this->cfg.opts >> GCOS_FORCE_16BIT_COLOR_MODE) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_USE_16BIT_TEXTURES);
+        g_GameErrorContext.Log(TH_ERR_USE_16BIT_TEXTURES);
     }
     if (this->IsUnknown())
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_FORCE_BACKBUFFER_CLEAR);
+        g_GameErrorContext.Log(TH_ERR_FORCE_BACKBUFFER_CLEAR);
     }
     if (((this->cfg.opts >> GCOS_DISPLAY_MINIMUM_GRAPHICS) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DONT_RENDER_ITEMS);
+        g_GameErrorContext.Log(TH_ERR_DONT_RENDER_ITEMS);
     }
     if (((this->cfg.opts >> GCOS_SUPPRESS_USE_OF_GOROUD_SHADING) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_GOURAUD_SHADING);
+        g_GameErrorContext.Log(TH_ERR_NO_GOURAUD_SHADING);
     }
     if (((this->cfg.opts >> GCOS_TURN_OFF_DEPTH_TEST) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_DEPTH_TESTING);
+        g_GameErrorContext.Log(TH_ERR_NO_DEPTH_TESTING);
     }
     if (((this->cfg.opts >> GCOS_FORCE_60FPS) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_FORCE_60FPS_MODE);
+        g_GameErrorContext.Log(TH_ERR_FORCE_60FPS_MODE);
         this->vsyncEnabled = 0;
     }
     if (((this->cfg.opts >> GCOS_NO_COLOR_COMP) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_NO_TEXTURE_COLOR_COMPOSITING);
+        g_GameErrorContext.Log(TH_ERR_NO_TEXTURE_COLOR_COMPOSITING);
     }
     if (((this->cfg.opts >> GCOS_NO_COLOR_COMP) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_LAUNCH_WINDOWED);
+        g_GameErrorContext.Log(TH_ERR_LAUNCH_WINDOWED);
     }
     if (((this->cfg.opts >> GCOS_REFERENCE_RASTERIZER_MODE) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_FORCE_REFERENCE_RASTERIZER);
+        g_GameErrorContext.Log(TH_ERR_FORCE_REFERENCE_RASTERIZER);
     }
     if (((this->cfg.opts >> GCOS_NO_DIRECTINPUT_PAD) & 1) != 0)
     {
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_DO_NOT_USE_DIRECTINPUT);
+        g_GameErrorContext.Log(TH_ERR_DO_NOT_USE_DIRECTINPUT);
     }
     if (FileSystem::WriteDataToFile(path, &g_Supervisor.cfg, sizeof(GameConfiguration)) != 0)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_FILE_CANNOT_BE_EXPORTED, path);
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_FOLDER_HAS_WRITE_PROTECT_OR_DISK_FULL);
+        g_GameErrorContext.Fatal(TH_ERR_FILE_CANNOT_BE_EXPORTED, path);
+        g_GameErrorContext.Fatal(TH_ERR_FOLDER_HAS_WRITE_PROTECT_OR_DISK_FULL);
         return ZUN_ERROR;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ stop:
     {
         g_GameErrorContext.ResetContext();
 
-        GameErrorContext::Log(&g_GameErrorContext, TH_ERR_OPTION_CHANGED_RESTART);
+        g_GameErrorContext.Log(TH_ERR_OPTION_CHANGED_RESTART);
 
         if (!g_Supervisor.cfg.windowed)
         {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,7 +24,7 @@ ZunResult CheckForRunningGameInstance(void)
     }
     else if (GetLastError() == ERROR_ALREADY_EXISTS)
     {
-        GameErrorContext::Fatal(&g_GameErrorContext, TH_ERR_ALREADY_RUNNING);
+        g_GameErrorContext.Fatal(TH_ERR_ALREADY_RUNNING);
         return ZUN_ERROR;
     }
 


### PR DESCRIPTION
Because `GameErrorContext::Log` and `GameErrorContext::Fatal` are variadic functions, even if they are `__thiscall` (which they probably were), the `this` pointer gets shoved onto the stack regardless. As such, there's no reason to make them static aside from needlessly making invoking them twice as verbose.