### PR TITLE
Add mention of portable branch to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 This project aims to perfectly reconstruct the source code of [Touhou Koumakyou ~ the Embodiment of Scarlet Devil 1.02h](https://en.touhouwiki.net/wiki/Embodiment_of_Scarlet_Devil) by Team Shanghai Alice.
 
+For a functioning port of the game to other platforms (Linux, modern Windows, etc), see [the portable branch](https://github.com/GensokyoClub/th06/tree/portable)
+
 ## Installation
 
 ### Executable


### PR DESCRIPTION
This adds a sentence near the top of the README mentioning that the portable branch exists and linking to it, since quite a large number of people seem to join the Discord without knowing that there's a port of the game off Windows.