### PR TITLE
Some variable/function names renaming

### DIFF
--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -151,7 +151,7 @@ th06::EnemyEclInstr::ExInsShootStarPattern
 th06::EnemyEclInstr::ExInsPatchouliShottypeSetVars
 th06::EnemyEclInstr::ExInsStage56Func4
 th06::EnemyEclInstr::ExInsStage5Func5
-th06::EnemyEclInstr::ExInsStage6XFunc6
+th06::EnemyEclInstr::ExInsBatWingEffect
 th06::EnemyEclInstr::ExInsStage6Func7
 th06::EnemyEclInstr::ExInsStage6Func8
 th06::EnemyEclInstr::ExInsStage6Func9

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -156,7 +156,7 @@ th06::EnemyEclInstr::ExInsStage6Func7
 th06::EnemyEclInstr::ExInsStage6Func8
 th06::EnemyEclInstr::ExInsStage6Func9
 th06::EnemyEclInstr::ExInsStage6Func11
-th06::EnemyEclInstr::ExInsStage6XFunc10
+th06::EnemyEclInstr::ExInsHandleBatTransformation
 th06::EnemyEclInstr::ExInsStage4Func12
 th06::EnemyEclInstr::ExInsStageXFunc13
 th06::EnemyEclInstr::ExInsStageXFunc14

--- a/config/implemented.csv
+++ b/config/implemented.csv
@@ -161,7 +161,7 @@ th06::EnemyEclInstr::ExInsStage4Func12
 th06::EnemyEclInstr::ExInsStageXFunc13
 th06::EnemyEclInstr::ExInsStageXFunc14
 th06::EnemyEclInstr::ExInsStageXFunc15
-th06::EnemyEclInstr::ExInsStageXFunc16
+th06::EnemyEclInstr::ExInsFlandreFinalContextUpdate
 th06::Enemy::Enemy
 th06::Enemy::Move
 th06::Enemy::ClampPos

--- a/config/mapping.csv
+++ b/config/mapping.csv
@@ -66,7 +66,7 @@ th06::EnemyEclInstr::ExInsShootStarPattern,0x40bb80,0x574,default,,void,Enemy*,E
 th06::EnemyEclInstr::ExInsPatchouliShottypeSetVars,0x40c100,0x75,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage56Func4,0x40c180,0x42a,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage5Func5,0x40c5b0,0x533,default,,void,Enemy*,EclRawInstr*
-th06::EnemyEclInstr::ExInsStage6XFunc6,0x40caf0,0x550,default,,void,Enemy*,EclRawInstr*
+th06::EnemyEclInstr::ExInsBatWingEffect,0x40caf0,0x550,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage6Func7,0x40d040,0x3bb,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage6Func8,0x40d400,0x125,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage6Func9,0x40d530,0x238,default,,void,Enemy*,EclRawInstr*

--- a/config/mapping.csv
+++ b/config/mapping.csv
@@ -76,7 +76,7 @@ th06::EnemyEclInstr::ExInsStage4Func12,0x40daa0,0x114,default,,void,Enemy*,EclRa
 th06::EnemyEclInstr::ExInsStageXFunc13,0x40dbc0,0xf2,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStageXFunc14,0x40dcc0,0x139,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStageXFunc15,0x40de00,0x3ae,default,,void,Enemy*,EclRawInstr*
-th06::EnemyEclInstr::ExInsStageXFunc16,0x40e1b0,0x114,default,,void,Enemy*,EclRawInstr*
+th06::EnemyEclInstr::ExInsFlandreFinalContextUpdate,0x40e1b0,0x114,default,,void,Enemy*,EclRawInstr*
 th06::EffectManager::EffectManager,0x40e2d0,0x65,__thiscall,,u32*,EffectManager*
 th06::EffectManager::Reset,0x40e340,0x19,__thiscall,,void,EffectManager*
 th06::EffectManager::EffectCallbackRandomSplash,0x40e360,0x24d,default,,i32,Effect*

--- a/config/mapping.csv
+++ b/config/mapping.csv
@@ -71,7 +71,7 @@ th06::EnemyEclInstr::ExInsStage6Func7,0x40d040,0x3bb,default,,void,Enemy*,EclRaw
 th06::EnemyEclInstr::ExInsStage6Func8,0x40d400,0x125,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage6Func9,0x40d530,0x238,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage6Func11,0x40d770,0x1b6,default,,void,Enemy*,EclRawInstr*
-th06::EnemyEclInstr::ExInsStage6XFunc10,0x40d930,0x164,default,,void,Enemy*,EclRawInstr*
+th06::EnemyEclInstr::ExInsHandleBatTransformation,0x40d930,0x164,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStage4Func12,0x40daa0,0x114,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStageXFunc13,0x40dbc0,0xf2,default,,void,Enemy*,EclRawInstr*
 th06::EnemyEclInstr::ExInsStageXFunc14,0x40dcc0,0x139,default,,void,Enemy*,EclRawInstr*

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -667,7 +667,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->flags.unk7 = instruction->args.setInt;
                 break;
             case ECL_OPCODE_ENEMYFLAGCANTAKEDAMAGE:
-                enemy->flags.unk10 = instruction->args.setInt;
+                enemy->flags.isDamageable = instruction->args.setInt;
                 break;
             case ECL_OPCODE_EFFECTSOUND:
                 g_SoundPlayer.PlaySoundByIdx((SoundIdx)instruction->args.setInt, 0);

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -907,7 +907,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->bulletRankAmount2High = args->bulletRankInfluence.bulletRankAmount2High;
                 break;
             case ECL_OPCODE_ENEMYFLAGINVISIBLE:
-                enemy->flags.unk15 = instruction->args.setInt;
+                enemy->flags.isInvisible = instruction->args.setInt;
                 break;
             case ECL_OPCODE_BOSSTIMERCLEAR:
                 enemy->timerCallbackSub = enemy->deathCallbackSub;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -914,7 +914,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->bossTimer.SetCurrent(0);
                 break;
             case ECL_OPCODE_SPELLCARDFLAGTIMEOUT:
-                enemy->flags.unk16 = instruction->args.setInt;
+                enemy->flags.isTimeoutSpell = instruction->args.setInt;
                 break;
             }
         NEXT_INSN:

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -27,7 +27,7 @@ DIFFABLE_STATIC_ARRAY_ASSIGN(ExInsn, 17, g_EclExInsn) = {
     EnemyEclInstr::ExInsCirnoRainbowBallJank, EnemyEclInstr::ExInsShootAtRandomArea,
     EnemyEclInstr::ExInsShootStarPattern,     EnemyEclInstr::ExInsPatchouliShottypeSetVars,
     EnemyEclInstr::ExInsStage56Func4,         EnemyEclInstr::ExInsStage5Func5,
-    EnemyEclInstr::ExInsStage6XFunc6,         EnemyEclInstr::ExInsStage6Func7,
+    EnemyEclInstr::ExInsBatWingEffect,         EnemyEclInstr::ExInsStage6Func7,
     EnemyEclInstr::ExInsStage6Func8,          EnemyEclInstr::ExInsStage6Func9,
     EnemyEclInstr::ExInsHandleBatTransformation,        EnemyEclInstr::ExInsStage6Func11,
     EnemyEclInstr::ExInsStage4Func12,         EnemyEclInstr::ExInsStageXFunc13,

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -792,7 +792,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->timerCallbackSub = instruction->args.setInt;
                 break;
             case ECL_OPCODE_ENEMYFLAGINTERACTABLE:
-                enemy->flags.unk6 = instruction->args.setInt;
+                enemy->flags.isInteractable = instruction->args.setInt;
                 break;
             case ECL_OPCODE_EFFECTPARTICLE:
                 g_EffectManager.SpawnParticles(instruction->args.effectParticle.effectId, &enemy->position,
@@ -868,7 +868,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                     }
 
                     local_b4->life = 0;
-                    if (local_b4->flags.unk6 == 0 && 0 <= local_b4->deathCallbackSub)
+                    if (local_b4->flags.isInteractable == 0 && 0 <= local_b4->deathCallbackSub)
                     {
                         g_EclManager.CallEclSub(&local_b4->currentContext, local_b4->deathCallbackSub);
                         local_b4->deathCallbackSub = -1;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -397,7 +397,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 local_14 = local_54->color;
                 // TODO: Strict aliasing rule be like.
                 local_58->spriteOffset = *EnemyEclInstr::GetVar(enemy, (EclVarId *)&local_14, NULL);
-                if (enemy->flags.unk3 == 0)
+                if (enemy->flags.shootingDisabled == 0)
                 {
                     g_BulletManager.SpawnBulletPattern(local_58);
                 }
@@ -432,10 +432,10 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 }
                 break;
             case ECL_OPCODE_SHOOTDISABLED:
-                enemy->flags.unk3 = 1;
+                enemy->flags.shootingDisabled = 1;
                 break;
             case ECL_OPCODE_SHOOTENABLED:
-                enemy->flags.unk3 = 0;
+                enemy->flags.shootingDisabled = 0;
                 break;
             case ECL_OPCODE_SHOOTNOW:
                 enemy->bulletProps.position = enemy->position + enemy->shootOffset;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -29,7 +29,7 @@ DIFFABLE_STATIC_ARRAY_ASSIGN(ExInsn, 17, g_EclExInsn) = {
     EnemyEclInstr::ExInsStage56Func4,         EnemyEclInstr::ExInsStage5Func5,
     EnemyEclInstr::ExInsStage6XFunc6,         EnemyEclInstr::ExInsStage6Func7,
     EnemyEclInstr::ExInsStage6Func8,          EnemyEclInstr::ExInsStage6Func9,
-    EnemyEclInstr::ExInsStage6XFunc10,        EnemyEclInstr::ExInsStage6Func11,
+    EnemyEclInstr::ExInsHandleBatTransformation,        EnemyEclInstr::ExInsStage6Func11,
     EnemyEclInstr::ExInsStage4Func12,         EnemyEclInstr::ExInsStageXFunc13,
     EnemyEclInstr::ExInsStageXFunc14,         EnemyEclInstr::ExInsStageXFunc15,
     EnemyEclInstr::ExInsStageXFunc16};

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -552,55 +552,55 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 break;
             case ECL_OPCODE_MOVEDIRTIMEDECELERATE:
                 EnemyEclInstr::MoveDirTime(enemy, instruction);
-                enemy->flags.unk2 = 1;
+                enemy->flags.movementEaseType = 1;
                 break;
             case ECL_OPCODE_MOVEDIRTIMEDECELERATEFAST:
                 EnemyEclInstr::MoveDirTime(enemy, instruction);
-                enemy->flags.unk2 = 2;
+                enemy->flags.movementEaseType = 2;
                 break;
             case ECL_OPCODE_MOVEDIRTIMEACCELERATE:
                 EnemyEclInstr::MoveDirTime(enemy, instruction);
-                enemy->flags.unk2 = 3;
+                enemy->flags.movementEaseType = 3;
                 break;
             case ECL_OPCODE_MOVEDIRTIMEACCELERATEFAST:
                 EnemyEclInstr::MoveDirTime(enemy, instruction);
-                enemy->flags.unk2 = 4;
+                enemy->flags.movementEaseType = 4;
                 break;
             case ECL_OPCODE_MOVEPOSITIONTIMELINEAR:
                 EnemyEclInstr::MovePosTime(enemy, instruction);
-                enemy->flags.unk2 = 0;
+                enemy->flags.movementEaseType = 0;
                 break;
             case ECL_OPCODE_MOVEPOSITIONTIMEDECELERATE:
                 EnemyEclInstr::MovePosTime(enemy, instruction);
-                enemy->flags.unk2 = 1;
+                enemy->flags.movementEaseType = 1;
                 break;
             case ECL_OPCODE_MOVEPOSITIONTIMEDECELERATEFAST:
                 EnemyEclInstr::MovePosTime(enemy, instruction);
-                enemy->flags.unk2 = 2;
+                enemy->flags.movementEaseType = 2;
                 break;
             case ECL_OPCODE_MOVEPOSITIONTIMEACCELERATE:
                 EnemyEclInstr::MovePosTime(enemy, instruction);
-                enemy->flags.unk2 = 3;
+                enemy->flags.movementEaseType = 3;
                 break;
             case ECL_OPCODE_MOVEPOSITIONTIMEACCELERATEFAST:
                 EnemyEclInstr::MovePosTime(enemy, instruction);
-                enemy->flags.unk2 = 4;
+                enemy->flags.movementEaseType = 4;
                 break;
             case ECL_OPCODE_MOVETIMEDECELERATE:
                 EnemyEclInstr::MoveTime(enemy, instruction);
-                enemy->flags.unk2 = 1;
+                enemy->flags.movementEaseType = 1;
                 break;
             case ECL_OPCODE_MOVETIMEDECELERATEFAST:
                 EnemyEclInstr::MoveTime(enemy, instruction);
-                enemy->flags.unk2 = 2;
+                enemy->flags.movementEaseType = 2;
                 break;
             case ECL_OPCODE_MOVETIMEACCELERATE:
                 EnemyEclInstr::MoveTime(enemy, instruction);
-                enemy->flags.unk2 = 3;
+                enemy->flags.movementEaseType = 3;
                 break;
             case ECL_OPCODE_MOVETIMEACCELERATEFAST:
                 EnemyEclInstr::MoveTime(enemy, instruction);
-                enemy->flags.unk2 = 4;
+                enemy->flags.movementEaseType = 4;
                 break;
             case ECL_OPCODE_MOVEBOUNDSSET:
                 enemy->lowerMoveLimit.x = instruction->args.moveBoundSet.lowerMoveLimit.x;
@@ -939,7 +939,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 {
                     local_bc = 1.0f;
                 }
-                switch (enemy->flags.unk2)
+                switch (enemy->flags.movementEaseType)
                 {
                 case 0:
                     local_bc = 1.0f - local_bc;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -817,7 +817,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 }
                 break;
             case ECL_OPCODE_ANMFLAGROTATION:
-                enemy->flags.unk13 = instruction->args.setInt;
+                enemy->flags.rotateAnm = instruction->args.setInt;
                 break;
             case ECL_OPCODE_EXINSCALL:
                 g_EclExInsn[instruction->args.setInt](enemy, instruction);

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -23,16 +23,23 @@ DIFFABLE_STATIC_ARRAY_ASSIGN(i32, 64, g_SpellcardScore) = {
     700000, 700000, 700000, 700000, 700000, 700000, 700000, 700000, 700000, 700000, 700000, 700000};
 DIFFABLE_STATIC(EclManager, g_EclManager);
 typedef void (*ExInsn)(Enemy *, EclRawInstr *);
-DIFFABLE_STATIC_ARRAY_ASSIGN(ExInsn, 17, g_EclExInsn) = {
-    EnemyEclInstr::ExInsCirnoRainbowBallJank, EnemyEclInstr::ExInsShootAtRandomArea,
-    EnemyEclInstr::ExInsShootStarPattern,     EnemyEclInstr::ExInsPatchouliShottypeSetVars,
-    EnemyEclInstr::ExInsStage56Func4,         EnemyEclInstr::ExInsStage5Func5,
-    EnemyEclInstr::ExInsBatWingEffect,         EnemyEclInstr::ExInsStage6Func7,
-    EnemyEclInstr::ExInsStage6Func8,          EnemyEclInstr::ExInsStage6Func9,
-    EnemyEclInstr::ExInsHandleBatTransformation,        EnemyEclInstr::ExInsStage6Func11,
-    EnemyEclInstr::ExInsStage4Func12,         EnemyEclInstr::ExInsStageXFunc13,
-    EnemyEclInstr::ExInsStageXFunc14,         EnemyEclInstr::ExInsStageXFunc15,
-    EnemyEclInstr::ExInsStageXFunc16};
+DIFFABLE_STATIC_ARRAY_ASSIGN(ExInsn, 17, g_EclExInsn) = {EnemyEclInstr::ExInsCirnoRainbowBallJank,
+                                                         EnemyEclInstr::ExInsShootAtRandomArea,
+                                                         EnemyEclInstr::ExInsShootStarPattern,
+                                                         EnemyEclInstr::ExInsPatchouliShottypeSetVars,
+                                                         EnemyEclInstr::ExInsStage56Func4,
+                                                         EnemyEclInstr::ExInsStage5Func5,
+                                                         EnemyEclInstr::ExInsBatWingEffect,
+                                                         EnemyEclInstr::ExInsStage6Func7,
+                                                         EnemyEclInstr::ExInsStage6Func8,
+                                                         EnemyEclInstr::ExInsStage6Func9,
+                                                         EnemyEclInstr::ExInsHandleBatTransformation,
+                                                         EnemyEclInstr::ExInsStage6Func11,
+                                                         EnemyEclInstr::ExInsStage4Func12,
+                                                         EnemyEclInstr::ExInsStageXFunc13,
+                                                         EnemyEclInstr::ExInsStageXFunc14,
+                                                         EnemyEclInstr::ExInsStageXFunc15,
+                                                         EnemyEclInstr::ExInsFlandreFinalContextUpdate};
 
 ZunResult EclManager::Load(char *eclPath)
 {

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -318,34 +318,34 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->axisSpeed.x = *EnemyEclInstr::GetVarFloat(enemy, &enemy->axisSpeed.x, NULL);
                 enemy->axisSpeed.y = *EnemyEclInstr::GetVarFloat(enemy, &enemy->axisSpeed.y, NULL);
                 enemy->axisSpeed.z = *EnemyEclInstr::GetVarFloat(enemy, &enemy->axisSpeed.z, NULL);
-                enemy->flags.unk1 = 0;
+                enemy->flags.movementMode = 0;
                 break;
             case ECL_OPCODE_MOVEVELOCITY:
                 local_8 = instruction->args.move.pos;
                 enemy->angle = *EnemyEclInstr::GetVarFloat(enemy, &local_8.x, NULL);
                 enemy->speed = *EnemyEclInstr::GetVarFloat(enemy, &local_8.y, NULL);
-                enemy->flags.unk1 = 1;
+                enemy->flags.movementMode = 1;
                 break;
             case ECL_OPCODE_MOVEANGULARVELOCITY:
                 local_8 = instruction->args.move.pos;
                 enemy->angularVelocity = *EnemyEclInstr::GetVarFloat(enemy, &local_8.x, NULL);
-                enemy->flags.unk1 = 1;
+                enemy->flags.movementMode = 1;
                 break;
             case ECL_OPCODE_MOVEATPLAYER:
                 local_8 = instruction->args.move.pos;
                 enemy->angle = g_Player.AngleToPlayer(&enemy->position) + local_8.x;
                 enemy->speed = *EnemyEclInstr::GetVarFloat(enemy, &local_8.y, NULL);
-                enemy->flags.unk1 = 1;
+                enemy->flags.movementMode = 1;
                 break;
             case ECL_OPCODE_MOVESPEED:
                 local_8 = instruction->args.move.pos;
                 enemy->speed = *EnemyEclInstr::GetVarFloat(enemy, &local_8.x, NULL);
-                enemy->flags.unk1 = 1;
+                enemy->flags.movementMode = 1;
                 break;
             case ECL_OPCODE_MOVEACCELERATION:
                 local_8 = instruction->args.move.pos;
                 enemy->acceleration = *EnemyEclInstr::GetVarFloat(enemy, &local_8.x, NULL);
-                enemy->flags.unk1 = 1;
+                enemy->flags.movementMode = 1;
                 break;
             case ECL_OPCODE_BULLETFANAIMED:
             case ECL_OPCODE_BULLETFAN:
@@ -923,7 +923,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
         }
         else
         {
-            switch (enemy->flags.unk1)
+            switch (enemy->flags.movementMode)
             {
             case 1:
                 enemy->angle = utils::AddNormalizeAngle(enemy->angle, g_Supervisor.effectiveFramerateMultiplier *
@@ -962,7 +962,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->angle = atan2f(enemy->axisSpeed.y, enemy->axisSpeed.x);
                 if ((ZunBool)(enemy->moveInterpTimer.current <= 0))
                 {
-                    enemy->flags.unk1 = 0;
+                    enemy->flags.movementMode = 0;
                     enemy->position = enemy->moveInterpStartPos + enemy->moveInterp;
                     enemy->axisSpeed = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
                 }

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -673,7 +673,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 g_SoundPlayer.PlaySoundByIdx((SoundIdx)instruction->args.setInt, 0);
                 break;
             case ECL_OPCODE_ENEMYFLAGDEATH:
-                enemy->flags.unk11 = instruction->args.setInt;
+                enemy->flags.deathMode = instruction->args.setInt;
                 break;
             case ECL_OPCODE_DEATHCALLBACKSUB:
                 enemy->deathCallbackSub = instruction->args.setInt;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -858,7 +858,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 for (local_b4 = &g_EnemyManager.enemies[0], local_b8 = 0;
                      local_b8 < ARRAY_SIZE_SIGNED(g_EnemyManager.enemies) - 1; local_b8++, local_b4++)
                 {
-                    if (!local_b4->flags.unk5)
+                    if (!local_b4->flags.isSlotOccupied)
                     {
                         continue;
                     }

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -664,7 +664,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->hitboxDimensions.z = instruction->args.move.pos.z;
                 break;
             case ECL_OPCODE_ENEMYFLAGCOLLISION:
-                enemy->flags.unk7 = instruction->args.setInt;
+                enemy->flags.isCollidable = instruction->args.setInt;
                 break;
             case ECL_OPCODE_ENEMYFLAGCANTAKEDAMAGE:
                 enemy->flags.isDamageable = instruction->args.setInt;

--- a/src/EclManager.cpp
+++ b/src/EclManager.cpp
@@ -243,13 +243,13 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
             HANDLE_CALL:
                 local_14 = instruction->args.call.eclSub;
                 enemy->currentContext.currentInstr = (EclRawInstr *)((u8 *)instruction + instruction->offsetToNext);
-                if (enemy->flags.unk14 == 0)
+                if (enemy->flags.disableCallStack == 0)
                 {
                     memcpy(&enemy->savedContextStack[enemy->stackDepth], &enemy->currentContext,
                            sizeof(EnemyEclContext));
                 }
                 g_EclManager.CallEclSub(&enemy->currentContext, (u16)local_14);
-                if (enemy->flags.unk14 == 0 && enemy->stackDepth < 7)
+                if (enemy->flags.disableCallStack == 0 && enemy->stackDepth < 7)
                 {
                     enemy->stackDepth++;
                 }
@@ -257,7 +257,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->currentContext.float0 = instruction->args.call.float0;
                 continue;
             case ECL_OPCODE_RET:
-                if (enemy->flags.unk14)
+                if (enemy->flags.disableCallStack)
                 {
                     utils::DebugPrint2("error : no Stack Ret\n");
                 }
@@ -685,7 +685,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 enemy->runInterrupt = instruction->args.setInt;
             HANDLE_INTERRUPT:
                 enemy->currentContext.currentInstr = (EclRawInstr *)((u8 *)instruction + instruction->offsetToNext);
-                if (enemy->flags.unk14 == 0)
+                if (enemy->flags.disableCallStack == 0)
                 {
                     memcpy(&enemy->savedContextStack[enemy->stackDepth], &enemy->currentContext,
                            sizeof(EnemyEclContext));
@@ -896,7 +896,7 @@ ZunResult EclManager::RunEcl(Enemy *enemy)
                 }
                 break;
             case ECL_OPCODE_ENEMYFLAGDISABLECALLSTACK:
-                enemy->flags.unk14 = instruction->args.setInt;
+                enemy->flags.disableCallStack = instruction->args.setInt;
                 break;
             case ECL_OPCODE_BULLETRANKINFLUENCE:
                 enemy->bulletRankSpeedLow = args->bulletRankInfluence.bulletRankSpeedLow;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -109,7 +109,7 @@ struct EnemyFlags
     u8 unk7 : 1;
     u8 unk8 : 1;
     u8 isBoss : 1;
-    u8 unk10 : 1;
+    u8 isDamageable : 1;
     u8 unk11 : 3;
 
     // Third byte

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -116,7 +116,7 @@ struct EnemyFlags
     bool shouldClampPos : 1;
     u8 rotateAnm : 1;
     u8 unk14 : 1;
-    u8 unk15 : 1;
+    u8 isInvisible : 1;
     u8 isTimeoutSpell : 1;
 
     // Rest is padding.

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -117,7 +117,7 @@ struct EnemyFlags
     u8 rotateAnm : 1;
     u8 unk14 : 1;
     u8 unk15 : 1;
-    u8 unk16 : 1;
+    u8 isTimeoutSpell : 1;
 
     // Rest is padding.
 };

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -105,7 +105,7 @@ struct EnemyFlags
     u8 unk5 : 1;
 
     // Second byte
-    u8 unk6 : 1;
+    u8 isInteractable : 1;
     u8 unk7 : 1;
     u8 unk8 : 1;
     u8 isBoss : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -114,7 +114,7 @@ struct EnemyFlags
 
     // Third byte
     bool shouldClampPos : 1;
-    u8 unk13 : 1;
+    u8 rotateAnm : 1;
     u8 unk14 : 1;
     u8 unk15 : 1;
     u8 unk16 : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -100,7 +100,7 @@ struct EnemyFlags
     // First byte
     u8 unk1 : 2;
     u8 unk2 : 3;
-    u8 unk3 : 1;
+    u8 shootingDisabled : 1;
     u8 unk4 : 1;
     u8 unk5 : 1;
 

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -99,7 +99,7 @@ struct EnemyFlags
 {
     // First byte
     u8 unk1 : 2;
-    u8 unk2 : 3;
+    u8 movementEaseType : 3;
     u8 shootingDisabled : 1;
     u8 unk4 : 1;
     u8 unk5 : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -98,7 +98,7 @@ ZUN_ASSERT_SIZE(EnemyEclContext, 0x4c);
 struct EnemyFlags
 {
     // First byte
-    u8 unk1 : 2;
+    u8 movementMode : 2;
     u8 movementEaseType : 3;
     u8 shootingDisabled : 1;
     u8 unk4 : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -106,7 +106,7 @@ struct EnemyFlags
 
     // Second byte
     u8 isInteractable : 1;
-    u8 unk7 : 1;
+    u8 isCollidable : 1;
     u8 hasBeenInBounds : 1;
     u8 isBoss : 1;
     u8 isDamageable : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -101,7 +101,7 @@ struct EnemyFlags
     u8 movementMode : 2;
     u8 movementEaseType : 3;
     u8 shootingDisabled : 1;
-    u8 unk4 : 1;
+    u8 invertX : 1;
     u8 isSlotOccupied : 1;
 
     // Second byte

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -115,7 +115,7 @@ struct EnemyFlags
     // Third byte
     bool shouldClampPos : 1;
     u8 rotateAnm : 1;
-    u8 unk14 : 1;
+    u8 disableCallStack : 1;
     u8 isInvisible : 1;
     u8 isTimeoutSpell : 1;
 

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -107,7 +107,7 @@ struct EnemyFlags
     // Second byte
     u8 isInteractable : 1;
     u8 unk7 : 1;
-    u8 unk8 : 1;
+    u8 hasBeenInBounds : 1;
     u8 isBoss : 1;
     u8 isDamageable : 1;
     u8 unk11 : 3;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -110,7 +110,7 @@ struct EnemyFlags
     u8 hasBeenInBounds : 1;
     u8 isBoss : 1;
     u8 isDamageable : 1;
-    u8 unk11 : 3;
+    u8 deathMode : 3;
 
     // Third byte
     bool shouldClampPos : 1;

--- a/src/Enemy.hpp
+++ b/src/Enemy.hpp
@@ -102,7 +102,7 @@ struct EnemyFlags
     u8 movementEaseType : 3;
     u8 shootingDisabled : 1;
     u8 unk4 : 1;
-    u8 unk5 : 1;
+    u8 isSlotOccupied : 1;
 
     // Second byte
     u8 isInteractable : 1;

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -742,7 +742,7 @@ void ExInsBatWingEffect(Enemy *enemy, EclRawInstr *instr)
     f32 finalAngle;
     D3DXVECTOR3 particlePos;
 
-    if (enemy->flags.unk15 != 0)
+    if (enemy->flags.isInvisible != 0)
     {
         Enemy::ResetEffectArray(enemy);
         return;

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -1048,7 +1048,7 @@ void ExInsHandleBatTransformation(Enemy *enemy, EclRawInstr *instr)
             enemy->anmExLeft = -1;
         }
 
-        enemy->flags.unk6 = 0;
+        enemy->flags.isInteractable = 0;
         enemy->exInsFunc10Timer.SetCurrent(60);
     }
     else
@@ -1061,7 +1061,7 @@ void ExInsHandleBatTransformation(Enemy *enemy, EclRawInstr *instr)
                 enemy->anmExLeft = 0xa1;
             }
 
-            enemy->flags.unk6 = 1;
+            enemy->flags.isInteractable = 1;
         }
     }
 }

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -734,7 +734,7 @@ void ExInsStage5Func5(Enemy *enemy, EclRawInstr *instr)
 }
 
 #pragma var_order(effect, baseAngleModifier, distanceModifier, finalAngle, particlePos)
-void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr)
+void ExInsBatWingEffect(Enemy *enemy, EclRawInstr *instr)
 {
     i32 baseAngleModifier;
     f32 distanceModifier;
@@ -1039,7 +1039,7 @@ void ExInsHandleBatTransformation(Enemy *enemy, EclRawInstr *instr)
         return;
     }
 
-    ExInsStage6XFunc6(enemy, instr);
+    ExInsBatWingEffect(enemy, instr);
     if (g_Player.bombInfo.isInUse != 0)
     {
         if (enemy->anmExLeft >= 0)

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -1032,7 +1032,7 @@ void ExInsStage6Func11(Enemy *enemy, EclRawInstr *instr)
     }
 }
 
-void ExInsStage6XFunc10(Enemy *enemy, EclRawInstr *instr)
+void ExInsHandleBatTransformation(Enemy *enemy, EclRawInstr *instr)
 {
     if (enemy->life <= 0)
     {
@@ -1202,7 +1202,7 @@ void ExInsStageXFunc15(Enemy *enemy, EclRawInstr *instr)
         }
     }
 
-    ExInsStage6XFunc10(enemy, instr);
+    ExInsHandleBatTransformation(enemy, instr);
     enemy->currentContext.var3 = totalIterations;
 }
 

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -15,7 +15,7 @@ namespace th06
 {
 namespace EnemyEclInstr
 {
-#define MAX_BOSS_TIME 7200
+#define RAGE_TIME_THRESHOLD 7200
 
 struct PatchouliShottypeVars
 {
@@ -1207,13 +1207,13 @@ void ExInsStageXFunc15(Enemy *enemy, EclRawInstr *instr)
 }
 
 #pragma var_order(remainingLife, rangeModifier)
-void ExInsStageXFunc16(Enemy *enemy, EclRawInstr *instr)
+void ExInsFlandreFinalContextUpdate(Enemy *enemy, EclRawInstr *instr)
 {
     f32 rangeModifier;
     i32 remainingLife;
 
     remainingLife = enemy->life;
-    if (enemy->bossTimer >= MAX_BOSS_TIME)
+    if (enemy->bossTimer >= RAGE_TIME_THRESHOLD)
     {
         remainingLife = 0;
     }

--- a/src/EnemyEclInstr.cpp
+++ b/src/EnemyEclInstr.cpp
@@ -55,7 +55,7 @@ void MoveDirTime(Enemy *enemy, EclRawInstr *instr)
 
     enemy->moveInterpTimer.SetCurrent(enemy->moveInterpStartTime);
 
-    enemy->flags.unk1 = 2;
+    enemy->flags.movementMode = 2;
 }
 
 void MovePosTime(Enemy *enemy, EclRawInstr *instr)
@@ -73,7 +73,7 @@ void MovePosTime(Enemy *enemy, EclRawInstr *instr)
 
     enemy->moveInterpTimer.SetCurrent(enemy->moveInterpStartTime);
 
-    enemy->flags.unk1 = 2;
+    enemy->flags.movementMode = 2;
     enemy->axisSpeed = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
 }
 
@@ -94,7 +94,7 @@ void MoveTime(Enemy *enemy, EclRawInstr *instr)
 
     enemy->moveInterpTimer.SetCurrent(enemy->moveInterpStartTime);
 
-    enemy->flags.unk1 = 2;
+    enemy->flags.movementMode = 2;
 }
 
 i32 *GetVar(Enemy *enemy, EclVarId *eclVarId, EclValueType *valueType)

--- a/src/EnemyEclInstr.hpp
+++ b/src/EnemyEclInstr.hpp
@@ -27,7 +27,7 @@ void ExInsShootStarPattern(Enemy *enemy, EclRawInstr *instr);
 void ExInsPatchouliShottypeSetVars(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage56Func4(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage5Func5(Enemy *enemy, EclRawInstr *instr);
-void ExInsStage6XFunc6(Enemy *enemy, EclRawInstr *instr);
+void ExInsBatWingEffect(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func7(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func8(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func9(Enemy *enemy, EclRawInstr *instr);

--- a/src/EnemyEclInstr.hpp
+++ b/src/EnemyEclInstr.hpp
@@ -37,6 +37,6 @@ void ExInsStage4Func12(Enemy *enemy, EclRawInstr *instr);
 void ExInsStageXFunc13(Enemy *enemy, EclRawInstr *instr);
 void ExInsStageXFunc14(Enemy *enemy, EclRawInstr *instr);
 void ExInsStageXFunc15(Enemy *enemy, EclRawInstr *instr);
-void ExInsStageXFunc16(Enemy *enemy, EclRawInstr *instr);
+void ExInsFlandreFinalContextUpdate(Enemy *enemy, EclRawInstr *instr);
 }; // namespace EnemyEclInstr
 }; // namespace th06

--- a/src/EnemyEclInstr.hpp
+++ b/src/EnemyEclInstr.hpp
@@ -32,7 +32,7 @@ void ExInsStage6Func7(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func8(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func9(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage6Func11(Enemy *enemy, EclRawInstr *instr);
-void ExInsStage6XFunc10(Enemy *enemy, EclRawInstr *instr);
+void ExInsHandleBatTransformation(Enemy *enemy, EclRawInstr *instr);
 void ExInsStage4Func12(Enemy *enemy, EclRawInstr *instr);
 void ExInsStageXFunc13(Enemy *enemy, EclRawInstr *instr);
 void ExInsStageXFunc14(Enemy *enemy, EclRawInstr *instr);

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -69,7 +69,7 @@ void EnemyManager::Initialize()
     enemy->anmExLeft = -1;
     enemy->anmExRight = -1;
     enemy->anmExDefaults = -1;
-    enemy->flags.unk10 = 1;
+    enemy->flags.isDamageable = 1;
     enemy->flags.unk11 = 0;
     enemy->deathCallbackSub = -1;
     enemy->flags.shouldClampPos = 0;
@@ -629,7 +629,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
                         damage = 0;
                     }
                 }
-                if (curEnemy->flags.unk10 != 0)
+                if (curEnemy->flags.isDamageable != 0)
                 {
                     curEnemy->life -= damage;
                 }
@@ -646,7 +646,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
                 {
                 case 3:
                     curEnemy->life = 1;
-                    curEnemy->flags.unk10 = 0;
+                    curEnemy->flags.isDamageable = 0;
                     curEnemy->flags.unk11 = 0;
                     g_Gui.bossPresent = 0;
                     g_EffectManager.SpawnParticles(curEnemy->deathAnm1, &curEnemy->position, 1, COLOR_WHITE);

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -580,7 +580,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
             }
         }
         local_8 = 0;
-        if (curEnemy->flags.hasBeenInBounds != 0 && !curEnemy->flags.unk15)
+        if (curEnemy->flags.hasBeenInBounds != 0 && !curEnemy->flags.isInvisible)
         {
             enemyLifeBeforeDmg = curEnemy->life;
             if (curEnemy->flags.unk7 && curEnemy->flags.isInteractable)
@@ -780,7 +780,7 @@ ChainCallbackResult EnemyManager::OnDraw(EnemyManager *mgr)
         {
             continue;
         }
-        if (curEnemy->flags.unk15)
+        if (curEnemy->flags.isInvisible)
         {
             continue;
         }

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -405,7 +405,7 @@ ZunBool Enemy::HandleTimerCallback()
         this->timerCallbackThreshold = -1;
         this->timerCallbackSub = this->deathCallbackSub;
         this->bossTimer.InitializeForPopup();
-        if (!this->flags.unk16)
+        if (!this->flags.isTimeoutSpell)
         {
             g_EnemyManager.spellcardInfo.isCapturing = false;
             if (g_EnemyManager.spellcardInfo.isActive)

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -44,7 +44,7 @@ void EnemyManager::Initialize()
     }
     enemy->flags.unk5 = 1;
     enemy->bossTimer.InitializeForPopup();
-    enemy->flags.unk6 = 1;
+    enemy->flags.isInteractable = 1;
     enemy->flags.unk7 = 1;
     enemy->flags.unk8 = 0;
     enemy->hitboxDimensions = D3DXVECTOR3(12.0f, 12.0f, 12.0f);
@@ -370,7 +370,7 @@ ZunBool Enemy::HandleLifeCallback()
             }
             curEnemy->life = 0;
 
-            if (!curEnemy->flags.unk6 && curEnemy->deathCallbackSub >= 0)
+            if (!curEnemy->flags.isInteractable && curEnemy->deathCallbackSub >= 0)
             {
                 g_EclManager.CallEclSub(&curEnemy->currentContext, curEnemy->deathCallbackSub);
                 curEnemy->deathCallbackSub = -1;
@@ -428,7 +428,7 @@ ZunBool Enemy::HandleTimerCallback()
             }
             curEnemy->life = 0;
 
-            if (!curEnemy->flags.unk6 && curEnemy->deathCallbackSub >= 0)
+            if (!curEnemy->flags.isInteractable && curEnemy->deathCallbackSub >= 0)
             {
                 g_EclManager.CallEclSub(&curEnemy->currentContext, curEnemy->deathCallbackSub);
                 curEnemy->deathCallbackSub = -1;
@@ -454,7 +454,7 @@ void Enemy::Despawn()
     }
     else
     {
-        this->flags.unk6 = 0;
+        this->flags.isInteractable = 0;
     }
     if (this->flags.isBoss)
     {
@@ -583,16 +583,16 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
         if (curEnemy->flags.unk8 != 0 && !curEnemy->flags.unk15)
         {
             enemyLifeBeforeDmg = curEnemy->life;
-            if (curEnemy->flags.unk7 && curEnemy->flags.unk6)
+            if (curEnemy->flags.unk7 && curEnemy->flags.isInteractable)
             {
                 enemyHitbox = curEnemy->hitboxDimensions / 1.5;
-                if (g_Player.CalcKillBoxCollision(&curEnemy->position, &enemyHitbox) == 1 && curEnemy->flags.unk6 &&
+                if (g_Player.CalcKillBoxCollision(&curEnemy->position, &enemyHitbox) == 1 && curEnemy->flags.isInteractable &&
                     !curEnemy->flags.isBoss)
                 {
                     curEnemy->life -= 10;
                 }
             }
-            if (curEnemy->flags.unk6 != 0)
+            if (curEnemy->flags.isInteractable != 0)
             {
                 damage = g_Player.CalcDamageToEnemy(&curEnemy->position, &curEnemy->hitboxDimensions, &local_8);
                 if (70 <= damage)
@@ -638,7 +638,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
                     g_Player.positionOfLastEnemyHit = curEnemy->position;
                 }
             }
-            if (0 >= curEnemy->life && curEnemy->flags.unk6 != 0)
+            if (0 >= curEnemy->life && curEnemy->flags.isInteractable != 0)
             {
                 curEnemy->lifeCallbackThreshold = -1;
                 curEnemy->timerCallbackThreshold = -1;
@@ -655,7 +655,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
                     break;
                 case 1:
                     g_GameManager.AddScore(curEnemy->score);
-                    curEnemy->flags.unk6 = 0;
+                    curEnemy->flags.isInteractable = 0;
                     goto LAB_00412a4d;
                 case 0:
                     g_GameManager.AddScore(curEnemy->score);

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -54,7 +54,7 @@ void EnemyManager::Initialize()
     enemy->acceleration = 0.0f;
     enemy->speed = 0.0f;
     enemy->flags.unk1 = 0;
-    enemy->flags.unk3 = 0;
+    enemy->flags.shootingDisabled = 0;
     enemy->flags.unk4 = 0;
     enemy->flags.isBoss = 0;
     enemy->stackDepth = 0;

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -79,7 +79,7 @@ void EnemyManager::Initialize()
     enemy->timerCallbackThreshold = -1;
     enemy->laserStore = 0;
     enemy->unk_e41 = 0;
-    enemy->flags.unk13 = 0;
+    enemy->flags.rotateAnm = 0;
     enemy->bulletRankSpeedLow = -0.5f;
     enemy->bulletRankSpeedHigh = 0.5f;
 }
@@ -798,7 +798,7 @@ ChainCallbackResult EnemyManager::OnDraw(EnemyManager *mgr)
                 g_AnmManager->Draw2(curEnemyVm);
             }
         }
-        if (curEnemy->flags.unk13 != 0)
+        if (curEnemy->flags.rotateAnm != 0)
         {
             curEnemy->primaryVm.rotation.z = curEnemy->angle;
         }

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -42,7 +42,7 @@ void EnemyManager::Initialize()
     {
         enemy->vms[i].anmFileIndex = -1;
     }
-    enemy->flags.unk5 = 1;
+    enemy->flags.isSlotOccupied = 1;
     enemy->bossTimer.InitializeForPopup();
     enemy->flags.isInteractable = 1;
     enemy->flags.unk7 = 1;
@@ -98,7 +98,7 @@ Enemy *EnemyManager::SpawnEnemy(i32 eclSubId, D3DXVECTOR3 *pos, i16 life, i16 it
     idx = 0;
     for (; idx < ARRAY_SIZE_SIGNED(this->enemies) - 1; idx++, newEnemy++)
     {
-        if (newEnemy->flags.unk5)
+        if (newEnemy->flags.isSlotOccupied)
             continue;
 
         *newEnemy = this->enemyTemplate;
@@ -316,7 +316,7 @@ void EnemyManager::RunEclTimeline()
                 break;
             case 0xc:
                 if (this->bosses[this->timelineInstr->arg0] != NULL &&
-                    this->bosses[this->timelineInstr->arg0]->flags.unk5)
+                    this->bosses[this->timelineInstr->arg0]->flags.isSlotOccupied)
                 {
                     this->timelineTime.Decrement(1);
                     return;
@@ -360,7 +360,7 @@ ZunBool Enemy::HandleLifeCallback()
         curEnemy = g_EnemyManager.enemies;
         for (i = 0; i < ARRAY_SIZE_SIGNED(g_EnemyManager.enemies) - 1; i++, curEnemy++)
         {
-            if (!curEnemy->flags.unk5)
+            if (!curEnemy->flags.isSlotOccupied)
             {
                 continue;
             }
@@ -418,7 +418,7 @@ ZunBool Enemy::HandleTimerCallback()
         curEnemy = g_EnemyManager.enemies;
         for (i = 0; i < ARRAY_SIZE_SIGNED(g_EnemyManager.enemies) - 1; i++, curEnemy++)
         {
-            if (!curEnemy->flags.unk5)
+            if (!curEnemy->flags.isSlotOccupied)
             {
                 continue;
             }
@@ -450,7 +450,7 @@ void Enemy::Despawn()
 {
     if (!this->flags.deathMode)
     {
-        this->flags.unk5 = 0;
+        this->flags.isSlotOccupied = 0;
     }
     else
     {
@@ -533,7 +533,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
     for (curEnemy = &mgr->enemies[0], mgr->enemyCount = 0, enemyIdx = 0; enemyIdx < ARRAY_SIZE_SIGNED(mgr->enemies) - 1;
          enemyIdx++, curEnemy++)
     {
-        if (!curEnemy->flags.unk5)
+        if (!curEnemy->flags.isSlotOccupied)
         {
             continue;
         }
@@ -550,7 +550,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
             !g_GameManager.IsInBounds(curEnemy->position.x, curEnemy->position.y, curEnemy->primaryVm.sprite->widthPx,
                                       curEnemy->primaryVm.sprite->heightPx))
         {
-            curEnemy->flags.unk5 = 0;
+            curEnemy->flags.isSlotOccupied = 0;
             curEnemy->Despawn();
             continue;
         }
@@ -564,7 +564,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
         }
         if (g_EclManager.RunEcl(curEnemy) == ZUN_ERROR)
         {
-            curEnemy->flags.unk5 = 0;
+            curEnemy->flags.isSlotOccupied = 0;
             curEnemy->Despawn();
             continue;
         }
@@ -659,7 +659,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
                     goto LAB_00412a4d;
                 case 0:
                     g_GameManager.AddScore(curEnemy->score);
-                    curEnemy->flags.unk5 = 0;
+                    curEnemy->flags.isSlotOccupied = 0;
                 LAB_00412a4d:
                     if (curEnemy->flags.isBoss)
                     {
@@ -776,7 +776,7 @@ ChainCallbackResult EnemyManager::OnDraw(EnemyManager *mgr)
     for (curEnemy = &mgr->enemies[0], curEnemyIdx = 0; curEnemyIdx < ARRAY_SIZE_SIGNED(mgr->enemies) - 1;
          curEnemyIdx++, curEnemy++)
     {
-        if (!curEnemy->flags.unk5)
+        if (!curEnemy->flags.isSlotOccupied)
         {
             continue;
         }

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -45,7 +45,7 @@ void EnemyManager::Initialize()
     enemy->flags.isSlotOccupied = 1;
     enemy->bossTimer.InitializeForPopup();
     enemy->flags.isInteractable = 1;
-    enemy->flags.unk7 = 1;
+    enemy->flags.isCollidable = 1;
     enemy->flags.hasBeenInBounds = 0;
     enemy->hitboxDimensions = D3DXVECTOR3(12.0f, 12.0f, 12.0f);
     enemy->axisSpeed = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
@@ -583,7 +583,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
         if (curEnemy->flags.hasBeenInBounds != 0 && !curEnemy->flags.isInvisible)
         {
             enemyLifeBeforeDmg = curEnemy->life;
-            if (curEnemy->flags.unk7 && curEnemy->flags.isInteractable)
+            if (curEnemy->flags.isCollidable && curEnemy->flags.isInteractable)
             {
                 enemyHitbox = curEnemy->hitboxDimensions / 1.5;
                 if (g_Player.CalcKillBoxCollision(&curEnemy->position, &enemyHitbox) == 1 && curEnemy->flags.isInteractable &&

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -586,8 +586,8 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
             if (curEnemy->flags.isCollidable && curEnemy->flags.isInteractable)
             {
                 enemyHitbox = curEnemy->hitboxDimensions / 1.5;
-                if (g_Player.CalcKillBoxCollision(&curEnemy->position, &enemyHitbox) == 1 && curEnemy->flags.isInteractable &&
-                    !curEnemy->flags.isBoss)
+                if (g_Player.CalcKillBoxCollision(&curEnemy->position, &enemyHitbox) == 1 &&
+                    curEnemy->flags.isInteractable && !curEnemy->flags.isBoss)
                 {
                     curEnemy->life -= 10;
                 }

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -53,7 +53,7 @@ void EnemyManager::Initialize()
     enemy->angle = 0.0f;
     enemy->acceleration = 0.0f;
     enemy->speed = 0.0f;
-    enemy->flags.unk1 = 0;
+    enemy->flags.movementMode = 0;
     enemy->flags.shootingDisabled = 0;
     enemy->flags.unk4 = 0;
     enemy->flags.isBoss = 0;

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -46,7 +46,7 @@ void EnemyManager::Initialize()
     enemy->bossTimer.InitializeForPopup();
     enemy->flags.isInteractable = 1;
     enemy->flags.unk7 = 1;
-    enemy->flags.unk8 = 0;
+    enemy->flags.hasBeenInBounds = 0;
     enemy->hitboxDimensions = D3DXVECTOR3(12.0f, 12.0f, 12.0f);
     enemy->axisSpeed = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
     enemy->angularVelocity = 0.0f;
@@ -540,13 +540,13 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
         mgr->enemyCount++;
         curEnemy->Move();
         curEnemy->ClampPos();
-        if (curEnemy->flags.unk8 == 0 &&
+        if (curEnemy->flags.hasBeenInBounds == 0 &&
             g_GameManager.IsInBounds(curEnemy->position.x, curEnemy->position.y, curEnemy->primaryVm.sprite->widthPx,
                                      curEnemy->primaryVm.sprite->heightPx))
         {
-            curEnemy->flags.unk8 = 1;
+            curEnemy->flags.hasBeenInBounds = 1;
         }
-        if (curEnemy->flags.unk8 == 1 &&
+        if (curEnemy->flags.hasBeenInBounds == 1 &&
             !g_GameManager.IsInBounds(curEnemy->position.x, curEnemy->position.y, curEnemy->primaryVm.sprite->widthPx,
                                       curEnemy->primaryVm.sprite->heightPx))
         {
@@ -580,7 +580,7 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
             }
         }
         local_8 = 0;
-        if (curEnemy->flags.unk8 != 0 && !curEnemy->flags.unk15)
+        if (curEnemy->flags.hasBeenInBounds != 0 && !curEnemy->flags.unk15)
         {
             enemyLifeBeforeDmg = curEnemy->life;
             if (curEnemy->flags.unk7 && curEnemy->flags.isInteractable)

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -70,7 +70,7 @@ void EnemyManager::Initialize()
     enemy->anmExRight = -1;
     enemy->anmExDefaults = -1;
     enemy->flags.isDamageable = 1;
-    enemy->flags.unk11 = 0;
+    enemy->flags.deathMode = 0;
     enemy->deathCallbackSub = -1;
     enemy->flags.shouldClampPos = 0;
     enemy->effectIdx = 0;
@@ -448,7 +448,7 @@ ZunBool Enemy::HandleTimerCallback()
 
 void Enemy::Despawn()
 {
-    if (!this->flags.unk11)
+    if (!this->flags.deathMode)
     {
         this->flags.unk5 = 0;
     }
@@ -642,12 +642,12 @@ ChainCallbackResult EnemyManager::OnUpdate(EnemyManager *mgr)
             {
                 curEnemy->lifeCallbackThreshold = -1;
                 curEnemy->timerCallbackThreshold = -1;
-                switch (curEnemy->flags.unk11)
+                switch (curEnemy->flags.deathMode)
                 {
                 case 3:
                     curEnemy->life = 1;
                     curEnemy->flags.isDamageable = 0;
-                    curEnemy->flags.unk11 = 0;
+                    curEnemy->flags.deathMode = 0;
                     g_Gui.bossPresent = 0;
                     g_EffectManager.SpawnParticles(curEnemy->deathAnm1, &curEnemy->position, 1, COLOR_WHITE);
                     g_EffectManager.SpawnParticles(curEnemy->deathAnm1, &curEnemy->position, 1, COLOR_WHITE);

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -55,7 +55,7 @@ void EnemyManager::Initialize()
     enemy->speed = 0.0f;
     enemy->flags.movementMode = 0;
     enemy->flags.shootingDisabled = 0;
-    enemy->flags.unk4 = 0;
+    enemy->flags.invertX = 0;
     enemy->flags.isBoss = 0;
     enemy->stackDepth = 0;
     enemy->life = 1;
@@ -197,7 +197,7 @@ void EnemyManager::RunEclTimeline()
                     args2 = &this->timelineInstr->args;
                     spawnedEnemy = this->SpawnEnemy(this->timelineInstr->arg0, args2->Var1AsVec(), args2->ushortVar1,
                                                     args2->ushortVar2, args2->uintVar4);
-                    spawnedEnemy->flags.unk4 = 1;
+                    spawnedEnemy->flags.invertX = 1;
                 }
                 break;
             case 3:
@@ -205,7 +205,7 @@ void EnemyManager::RunEclTimeline()
                 {
                     spawnedEnemy = this->SpawnEnemy(this->timelineInstr->arg0, this->timelineInstr->args.Var1AsVec(),
                                                     -1, ITEM_RANDOM_ITEM, -1);
-                    spawnedEnemy->flags.unk4 = 1;
+                    spawnedEnemy->flags.invertX = 1;
                 }
                 break;
             case 4:
@@ -267,7 +267,7 @@ void EnemyManager::RunEclTimeline()
                     }
                     spawnedEnemy = this->SpawnEnemy(this->timelineInstr->arg0, &pos3, args4->ushortVar1,
                                                     args4->ushortVar2, args4->uintVar4);
-                    spawnedEnemy->flags.unk4 = 1;
+                    spawnedEnemy->flags.invertX = 1;
                 }
                 break;
             case 7:
@@ -287,7 +287,7 @@ void EnemyManager::RunEclTimeline()
                         pos4.z = g_Rng.GetRandomF32InRange(800.0f);
                     }
                     spawnedEnemy = this->SpawnEnemy(this->timelineInstr->arg0, &pos4, -1, ITEM_RANDOM_ITEM, -1);
-                    spawnedEnemy->flags.unk4 = 1;
+                    spawnedEnemy->flags.invertX = 1;
                 }
                 break;
             case 8:
@@ -862,7 +862,7 @@ void EnemyManager::CutChain()
 
 void Enemy::Move()
 {
-    if (!this->flags.unk4)
+    if (!this->flags.invertX)
     {
         this->position.x += g_Supervisor.effectiveFramerateMultiplier * this->axisSpeed.x;
     }


### PR DESCRIPTION
## Flags renaming
Most of the renames come from zero's map https://github.com/zero318/TouhouMaps/blob/main/th06.eclm
Some other I had to derive from the code

## ExInsBatWingEffect
This just draws the white particle effects that draw the bat wings around Remilia/Flandre hence I named it as such

## ExInsHandleBatTransformation
This is run when the Remi/Flan turn into bats, hence I renamed it like that

## ExInsFlandreFinalContextUpdate
This one just updates a lot of local variables that depend on the enemy's current HP and/or how much time has passed, it determines the speed/fire rate of the rings in QED, I named it ``ContextUpdate`` because I don't know how else to name it so I hope that's good enough

## RAGE_TIME_THRESHOLD rename
So QED lasts for 9000 frames, which is 150 seconds. If you ever play QED the bullets will be very slow and they will only fire like once every 2 seconds, but they get faster if her HP gets lower (both bullet speed and fire rate)
Now you might think you could just not shoot and timeout so it'd be easy, but at the 30s mark (i.e. once 7200 frames have passed since the start of the spell) she will shoot bullets at max speed and at max fire rate
MAX_BOSS_TIME makes me think the spell lasts for 7200 frames, but it's not. She just enables her "rage" phase (as thprac setting likes to call it that) after 7200 frames, so I named it to RAGE_TIME_THRESHOLD instead 