### PR TITLE
[Supervisor] Use blank branches to match

### DIFF
--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -788,22 +788,16 @@ i32 Supervisor::PlayMidiFile(i32 midiFileIdx)
 
 ZunResult Supervisor::SetupMidiPlayback(char *path)
 {
-    // There doesn't seem to be a way to recreate the jump assembly needed without gotos?
-    // Standard short circuiting boolean operators and nested conditionals don't seem to work, at least
     if (g_Supervisor.cfg.musicMode == MIDI)
     {
-        goto success;
     }
     else if (g_Supervisor.cfg.musicMode == WAV)
     {
-        goto success;
     }
     else
     {
         return ZUN_ERROR;
     }
-
-success:
     return ZUN_SUCCESS;
 }
 


### PR DESCRIPTION
Compiler matches 100% on my end when I do this.